### PR TITLE
fix(tokens): normalize path separators on Windows

### DIFF
--- a/packages/tailwindcss-obfuscator/src/core/tokens.ts
+++ b/packages/tailwindcss-obfuscator/src/core/tokens.ts
@@ -207,7 +207,7 @@ export function groupTokensByFile(
     let filePath = token.file;
 
     if (options.relativeTo) {
-      filePath = path.relative(options.relativeTo, filePath);
+      filePath = path.relative(options.relativeTo, filePath).split(path.sep).join("/");
     }
 
     const existing = grouped.get(filePath) || [];


### PR DESCRIPTION
## Summary

The Windows runners (both Node 20 and Node 22) failed `tests/new-features.test.ts > groupTokensByFile > should support relative paths` on the fresh init's first CI run.

`path.relative()` returns OS-native separators, so on Windows `relativeTo` produced backslash-prefixed keys like `src\test.html` while the test (and any downstream consumer that walks the map) expects POSIX `src/test.html`.

## Fix

One-line normalization in `packages/tailwindcss-obfuscator/src/core/tokens.ts`:

```diff
- filePath = path.relative(options.relativeTo, filePath);
+ filePath = path.relative(options.relativeTo, filePath).split(path.sep).join("/");
```

POSIX paths are the right canonical form here — they match how the rest of the package emits paths into the obfuscation report and the `class-mapping.json` artefact.

## Test plan

- [x] All 360 unit tests pass locally on macOS
- [x] CI matrix should now turn green on the 3rd Windows cell that was previously red (Node 20 + Node 22 × `windows-latest`)