### PR TITLE
ci(release): gate publish step behind 'npm' environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: npm
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Wires the \`release\` job in \`.github/workflows/release.yml\` to the \`npm\` environment that \`setup-repo.sh\` step 9 already created. With this in place, the workflow pauses on every run and waits for josedacosta to approve before \`NPM_TOKEN\` is injected and \`changeset publish\` reaches \`npm publish\`.

This matches the pattern in \`jose/scripts/github/browser-manual.md\` §9 ("the secret is only injected during the actual publish step").

## Why now

\`setup-repo.sh\` step 9 (added in this session) creates the env with a required reviewer + main-only branch policy. The env was sitting unused because the workflow didn't reference it. After this PR, the existing protection on the env starts gating \`npm publish\`.

## Trade-off — known and accepted

Adding \`environment: npm\` to the **whole** \`release\` job means the no-op path (most pushes — i.e. those without pending changesets) also pauses for approval. The alternative (split into version + publish jobs, where only the publish job inherits the env) adds significant YAML complexity for a one-click cost on each push. We can split later if the friction becomes a problem.

## Test plan

- [ ] Once \`NPM_TOKEN\` is added to the \`npm\` env (\`gh secret set NPM_TOKEN --env npm\`), this PR's CI run shows the release job in the "waiting for approval" state on the Actions page
- [ ] Approving the run from the env page lets the rest of the job execute
- [ ] No regression on the docs/CI workflows