### PR TITLE
docs: factual cleanup pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@
 
 <!-- ────────────────────────────────────────────────── -->
 
+---
+
 ## 📖 Documentation
 
 <div align="center">
@@ -101,6 +103,8 @@ Setup guide for every framework · complete options reference · the patterns th
 | Hosted on GitHub Pages, rebuilt on every push to `main`                        | Edit a page, open a PR              |
 
 </div>
+
+---
 
 <!-- ────────────────────────────────────────────────── -->
 
@@ -215,21 +219,24 @@ There are a handful of class-mangling tools out there. Here's how this one stack
 
 <div align="center">
 
-| Capability                                            | 🛡️&nbsp;&nbsp;**tailwindcss-obfuscator** | 🔧&nbsp;&nbsp;tailwindcss-mangle | ⚙️&nbsp;&nbsp;PostCSS minifiers |
-| ----------------------------------------------------- | :--------------------------------------: | :------------------------------: | :-----------------------------: |
-| Tailwind v4 (CSS-first) support                       |                ✅ Native                 |            ⚠️ Partial            |               ❌                |
-| Unified `unplugin` core (Vite/Webpack/Rollup/esbuild) |                    ✅                    |          ⚠️ Per-bundler          |               ❌                |
-| AST-based JSX/TSX transformer                         |                 ✅ Babel                 |             ⚠️ Regex             |               ❌                |
-| Svelte `class:directive` support                      |                    ✅                    |                ❌                |               ❌                |
-| `cn()` / `clsx()` / `cva()` / `tv()` extraction       |               ✅ All five                |              ⚠️ Two              |               ❌                |
-| Type-safe options + typed errors                      |               ✅ Strict TS               |             ⚠️ Loose             |               n/a               |
-| Source maps for transformed files                     |                    ✅                    |                ⚠️                |               ✅                |
-| Standalone CLI (any project)                          |            ✅ `tw-obfuscator`            |                ❌                |               ❌                |
-| Per-build randomization (no global state)             |                    ✅                    |                ❌                |               n/a               |
-| Tailwind config validator                             |                    ✅                    |                ❌                |               ❌                |
-| Active framework coverage                             |               **13+ apps**               |                ~5                |               n/a               |
+| Capability                                                                    | 🛡️&nbsp;&nbsp;**tailwindcss-obfuscator** | 🔧&nbsp;&nbsp;tailwindcss-mangle | ⚙️&nbsp;&nbsp;PostCSS minifiers |
+| ----------------------------------------------------------------------------- | :--------------------------------------: | :------------------------------: | :-----------------------------: |
+| Tailwind v4 (CSS-first) support                                               |        ✅ Native (AST + PostCSS)         |  ✅ via CSS scanning (v9.0.0+)   |               ❌                |
+| Unified `unplugin` core (Vite/Webpack/Rollup/esbuild/**Rspack**/**Farm**)     |                    ✅                    |          ⚠️ Per-bundler          |               ❌                |
+| AST-based JSX/TSX transformer                                                 |                 ✅ Babel                 |             ⚠️ Regex             |               ❌                |
+| Svelte `class:directive` support                                              |                    ✅                    |                ❌                |               ❌                |
+| Class-utility extraction (`cn`, `clsx`, `classnames`, `twMerge`, `cva`, `tv`) |                ✅ All six                |              ⚠️ Two              |               ❌                |
+| Type-safe options + typed errors                                              |               ✅ Strict TS               |             ⚠️ Loose             |               n/a               |
+| Source maps for transformed files                                             |                    ✅                    |                ⚠️                |               ✅                |
+| Standalone CLI (any project)                                                  |            ✅ `tw-obfuscator`            |                ❌                |               ❌                |
+| Per-build randomization (no global state)                                     |                    ✅                    |                ❌                |               n/a               |
+| Tailwind config validator                                                     |                    ✅                    |                ❌                |               ❌                |
+| Active framework coverage                                                     |               **20+ apps**               |                ~5                |               n/a               |
 
 </div>
+
+> [!NOTE]
+> **About `tailwindcss-mangle`** — its `tailwindcss-patch@9.0.0` release added Tailwind v4 support via CSS scanning, but the goal is class **mangling for tree-shaking**, not full **obfuscation** (it doesn't rewrite source files end-to-end and has no AST transformer). For a side-by-side technical breakdown see [`/docs/research/tailwindcss-patch.md`](./docs/research/tailwindcss-patch.md).
 
 <!-- ────────────────────────────────────────────────── -->
 
@@ -734,7 +741,7 @@ Framework guides, migration tips, FAQ
 
 **[Example apps](./apps/)**
 
-13+ working examples, one per supported framework
+20+ working examples, one per supported framework
 
 </td>
 </tr>

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -114,7 +114,10 @@ export default defineConfig({
         },
         {
           text: "Resources",
-          items: [{ text: "Brand Assets", link: "/guide/brand-assets" }],
+          items: [
+            { text: "Brand Assets", link: "/guide/brand-assets" },
+            { text: "Maintainers' Checklist", link: "/maintainers" },
+          ],
         },
       ],
       "/reference/": [

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ hero:
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/josedacosta/tailwindcss-obfuscation
+      link: https://github.com/josedacosta/tailwindcss-obfuscator
 
 features:
   - icon:

--- a/docs/research/ecosystem.md
+++ b/docs/research/ecosystem.md
@@ -54,12 +54,13 @@ Patches Tailwind CSS source code at install time to expose internal APIs that ar
 
 ### Tailwind Version Support
 
-| tailwindcss-patch | Tailwind CSS |
-| ----------------- | ------------ |
-| v3.x              | v3.x         |
-| v2.x              | v3.x (older) |
+| tailwindcss-patch | Tailwind CSS      | Method                                         |
+| ----------------- | ----------------- | ---------------------------------------------- |
+| v9.0.0+           | v3.x · v4.x       | Runtime patching (v3) + CSS scanning (v4)      |
+| v8.x              | v3.x · v4 partial | Limited Oxide support, several blocking issues |
+| v3.x              | v3.x              | Classic runtime patching (legacy)              |
 
-**Important**: As of now, `tailwindcss-patch` does NOT support Tailwind CSS v4 due to the complete architectural rewrite (Oxide engine in Rust).
+**v9.0.0 update (April 2026)**: `tailwindcss-patch` shipped first-class Tailwind v4 support, but through a **CSS-scanning** approach (`--css` flag): it parses the compiled CSS to discover which classes Tailwind generated, instead of patching the v3 runtime. This works around the Oxide rewrite but it's a fundamentally different method from `tailwindcss-obfuscator`'s AST + PostCSS pipeline. See [/research/tailwindcss-patch](./tailwindcss-patch.md) for the side-by-side breakdown.
 
 ## unplugin-tailwindcss-mangle
 
@@ -125,19 +126,22 @@ sonofmagic/tailwindcss-mangle/
 
 Understanding this ecosystem is crucial for our `tailwindcss-obfuscator` because:
 
-1. **Same problem domain**: We're solving the same problem (class obfuscation)
-2. **Reference implementation**: Their approach to class extraction and transformation is valuable
-3. **Tailwind v4 gap**: Neither package supports Tailwind v4 yet - this is our opportunity
-4. **Architecture insights**: Their monorepo structure and plugin patterns are good references
+1. **Adjacent problem domain**: `tailwindcss-mangle` mangles classes for tree-shaking; we obfuscate them for design-system protection. Same input, different output goal.
+2. **Reference implementation**: Their approach to class extraction informed our pattern catalog.
+3. **Tailwind v4 gap (now closed differently)**: Until v9.0.0 (April 2026), neither package supported Tailwind v4. v9.0.0 added v4 support via CSS scanning — a different mechanism from our AST + PostCSS pipeline. We now coexist rather than fill a void.
+4. **Architecture insights**: Their monorepo + unplugin layout is a useful baseline.
 
 ## Key Differences from Our Approach
 
-| Aspect            | tailwindcss-mangle | Our tailwindcss-obfuscator |
-| ----------------- | ------------------ | -------------------------- |
-| Tailwind v4       | Not supported      | Supported                  |
-| Patching required | Yes (`tw-patch`)   | No                         |
-| Class extraction  | Runtime via patch  | Static analysis            |
-| Build tools       | unplugin-based     | unplugin-based             |
+| Aspect                   | tailwindcss-mangle (v9.0.0+)           | Our tailwindcss-obfuscator                            |
+| ------------------------ | -------------------------------------- | ----------------------------------------------------- |
+| Goal                     | Class mangling for bundle tree-shaking | Full obfuscation (design-system protection)           |
+| Tailwind v4              | ✅ via CSS scanning                    | ✅ via AST + PostCSS (transforms source files too)    |
+| Patching `node_modules`  | Yes for v3 (`tw-patch install`)        | ❌ Never                                              |
+| Class extraction         | Runtime patch (v3) / CSS scan (v4)     | Static analysis of source files                       |
+| Build tools              | Vite / Webpack / Rollup / Nuxt         | Vite / Webpack / Rollup / esbuild / Rspack / Farm     |
+| AST-based JSX/TSX        | ❌                                     | ✅ Babel                                              |
+| Class-utility extraction | 2 of 6                                 | All 6 (`cn`/`clsx`/`classnames`/`twMerge`/`cva`/`tv`) |
 
 ## Local Code for Reverse Engineering
 

--- a/docs/research/lab_tailwindcss_patch_analysis.md
+++ b/docs/research/lab_tailwindcss_patch_analysis.md
@@ -1,5 +1,9 @@
 # Lab Analysis: tailwindcss-patch + unplugin-tailwindcss-mangle
 
+::: warning Snapshot from December 2025 — refreshed April 2026
+This page reverse-engineered `tailwindcss-patch` **v8.x** and `unplugin-tailwindcss-mangle` **v5.0.x**. In April 2026 the upstream shipped `tailwindcss-patch@9.0.0` with explicit Tailwind v4 support via CSS scanning (the `--css` flag). The architectural finding below — runtime patching can't work on Tailwind v4's Oxide engine — is still correct; v9.0.0 sidesteps it by switching to a different mechanism. For the up-to-date positioning of both projects, read [/research/tailwindcss-patch](./tailwindcss-patch.md).
+:::
+
 This document presents a comprehensive reverse engineering analysis of `tailwindcss-patch` and `unplugin-tailwindcss-mangle` packages, testing their compatibility with Tailwind CSS v3 and v4.
 
 ## Executive Summary
@@ -26,8 +30,9 @@ This document presents a comprehensive reverse engineering analysis of `tailwind
 
 **Version Compatibility**:
 
-- **v3.0.x**: Works with Tailwind CSS v3 (PostCSS-based)
-- **v8.4.x**: Claims to support Tailwind CSS v4, but has critical issues
+- **v9.0.0+** (April 2026): Tailwind v3 (runtime patching) **and** v4 (CSS scanning via `--css` flag). Released after this lab analysis.
+- **v8.4.x** (this analysis): Claims to support Tailwind v4 but has critical issues (documented below).
+- **v3.0.x**: Tailwind v3 only (PostCSS-based runtime patch).
 
 ### unplugin-tailwindcss-mangle
 

--- a/docs/research/tailwindcss-patch.md
+++ b/docs/research/tailwindcss-patch.md
@@ -2,7 +2,16 @@
 
 ## Executive Summary
 
-The `tailwindcss-patch` library claims "first-class support for Tailwind CSS v4", but in practice, **its extraction functionality is broken** for v4 projects. This document explains the technical issues and why we created `tailwindcss-obfuscator` as a complete alternative.
+`tailwindcss-patch` and `tailwindcss-obfuscator` are often compared because both touch Tailwind class names at build time, but they solve **different problems** and use **different mechanisms**:
+
+- `tailwindcss-patch` (v9.0.0+) **mangles** class names to shrink the production bundle. It collects classes via runtime patching on Tailwind v3 and via CSS scanning on Tailwind v4 (the `--css` flag, added in v9.0.0).
+- `tailwindcss-obfuscator` **obfuscates** class names everywhere — source files, CSS, build artefacts — to make the design system hard to reverse-engineer. It uses an AST transformer (Babel) and a PostCSS pass, and never patches `node_modules`.
+
+This page collects the technical history (the v8.x → v9.0.0 transition explains a lot of the design space) and ends with a head-to-head feature comparison.
+
+::: warning Historical context
+Sections "The Problem with tailwindcss-patch" through "How tailwindcss-patch Works" describe `tailwindcss-patch` v8.x, where the v4 support was broken (this is what motivated `tailwindcss-obfuscator`). v9.0.0 fixed it via CSS scanning, but kept the mangling-only goal. The Feature Comparison and "Why we still differ" sections below cover v9.0.0+ and are the up-to-date reference.
+:::
 
 ## The Problem with tailwindcss-patch
 
@@ -110,19 +119,30 @@ This works because:
 
 ## Feature Comparison
 
-| Feature               | tailwindcss-patch        | tailwindcss-obfuscator |
-| --------------------- | ------------------------ | ---------------------- |
-| Tailwind v3 support   | ✅ Yes                   | ✅ Yes                 |
-| Tailwind v4 support   | ❌ No                    | ✅ Yes                 |
-| Requires patching     | Yes (`tw-patch install`) | No                     |
-| Build tool support    | Limited                  | All (via unplugin)     |
-| React/Next.js         | ✅ Yes                   | ✅ Yes                 |
-| Vue/Nuxt              | ⚠️ Partial               | ✅ Yes                 |
-| Svelte/SvelteKit      | ⚠️ Partial               | ✅ Yes                 |
-| Astro                 | ❌ No                    | ✅ Yes                 |
-| Class utility support | ❌ No                    | ✅ cn, clsx, cva, tv   |
-| Source maps           | ❌ No                    | ✅ Yes                 |
-| Persistent mapping    | ⚠️ Basic                 | ✅ Full with merge     |
+| Feature                                                                  | tailwindcss-patch (v9.0.0+)     | tailwindcss-obfuscator                                      |
+| ------------------------------------------------------------------------ | ------------------------------- | ----------------------------------------------------------- |
+| Goal                                                                     | Mangle classes for tree-shaking | Obfuscate classes (rewrite source + bundles end-to-end)     |
+| Tailwind v3 support                                                      | ✅ Yes (runtime patching)       | ✅ Yes                                                      |
+| Tailwind v4 support                                                      | ✅ Yes (CSS scanning, v9.0.0+)  | ✅ Yes (AST + PostCSS)                                      |
+| Requires patching `node_modules`                                         | Yes for v3 (`tw-patch install`) | ❌ Never                                                    |
+| Build-tool support                                                       | Limited                         | All (via unplugin: Vite/Webpack/Rollup/esbuild/Rspack/Farm) |
+| React/Next.js                                                            | ✅                              | ✅                                                          |
+| Vue/Nuxt                                                                 | ⚠️ Partial                      | ✅                                                          |
+| Svelte/SvelteKit                                                         | ⚠️ Partial                      | ✅                                                          |
+| Astro                                                                    | ❌                              | ✅                                                          |
+| Class-utility extraction (`cn`/`clsx`/`classnames`/`twMerge`/`cva`/`tv`) | ❌                              | ✅ All six                                                  |
+| AST-based JSX/TSX transform                                              | ❌                              | ✅ Babel                                                    |
+| Source maps                                                              | ❌                              | ✅                                                          |
+| Persistent mapping                                                       | ⚠️ Basic                        | ✅ With merge strategy                                      |
+
+> **Why we still differ from `tailwindcss-patch` v9.0.0**
+>
+> The two libraries solve adjacent but distinct problems:
+>
+> - **`tailwindcss-patch`** scans CSS output and content sources to collect Tailwind class names, then mangles them for **bundle size optimisation**. It's a shorter-cycle tool and stops once the class list is collected.
+> - **`tailwindcss-obfuscator`** rewrites class names everywhere — source files (JSX, Vue, Svelte, Astro), CSS selectors, build artefacts — to make the design system **uncopyable**. It needs an AST transformer, a PostCSS pass, and a full mapping persistence layer because every output file is touched.
+>
+> If you only care about bundle size and you're willing to accept the runtime patching for v3, `tailwindcss-patch` is lighter. If you need to ship a build whose CSS is genuinely hard to reverse-engineer, that's the `tailwindcss-obfuscator` use case.
 
 ## Build Output Comparison
 

--- a/docs/research/v4-issues.md
+++ b/docs/research/v4-issues.md
@@ -1,12 +1,14 @@
 # Mangle Tailwind v4 Issues
 
-> Technical issues with `tailwindcss-patch` and `unplugin-tailwindcss-mangle` on Tailwind CSS v4
+> Technical issues with `tailwindcss-patch` v8.x and `unplugin-tailwindcss-mangle` on Tailwind CSS v4
 
-**Date:** December 8, 2025
-**Project:** tailwindcss-obfuscation
+**Original investigation:** December 8, 2025 against Tailwind v4.1.17 + Next.js 15.5.7.
+**Refresh:** April 28, 2026 — Tailwind v4 is now at 4.2.4 and `tailwindcss-patch` shipped v9.0.0 with first-class v4 support via CSS scanning. The issues below remain accurate for the **v8.x branch**; the architectural objections (Oxide engine in Rust, no PostCSS hook) are why v9.0.0 had to switch mechanism. See [/research/tailwindcss-patch](./tailwindcss-patch.md) for the up-to-date positioning.
+
+**Project:** tailwindcss-obfuscator
 **App:** tailwind_v4_react_nextjs
-**Tailwind Version:** 4.1.17
-**Next.js Version:** 15.5.7
+**Tailwind Version (refreshed):** 4.2.4
+**Next.js Version (refreshed):** 16.x
 
 ---
 
@@ -309,7 +311,11 @@ The `unplugin-tailwindcss-mangle` maintainers need to:
 2. Fix the CSS loader context serialization bug
 3. Test with `@tailwindcss/postcss`
 
-**GitHub Issue to Watch:** https://github.com/sonofmagic/tailwindcss-mangle/issues
+**GitHub Issue to Watch:** <https://github.com/sonofmagic/tailwindcss-mangle/issues>
+
+::: info Update — April 2026
+`tailwindcss-mangle` released v9.0.0 in April 2026 with Tailwind v4 support through CSS scanning (the `--css` flag), confirming the diagnosis below: the v8.x runtime-patching path could not be fixed and a different mechanism was needed. The new approach works for tree-shaking but doesn't ship a full obfuscation pipeline; see [/research/tailwindcss-patch](./tailwindcss-patch.md) for the comparison.
+:::
 
 ### 8.3 Long-Term: Custom Solution
 

--- a/packages/tailwindcss-obfuscator/README.md
+++ b/packages/tailwindcss-obfuscator/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   Obfuscate Tailwind CSS class names at build time —<br/>
-  Vite · Webpack · Rollup · esbuild · Next.js · Nuxt · SvelteKit · Astro · Solid · Qwik · React Router 7 · TanStack Router.<br/>
+  Vite · Webpack · Rollup · esbuild · Rspack · Farm · Next.js · Nuxt · SvelteKit · Astro · Solid · Qwik · Vue · React Router 7 · TanStack Router.<br/>
   Tailwind <strong>v3</strong> &amp; <strong>v4</strong>.
 </p>
 
@@ -58,7 +58,7 @@ export default defineConfig({
 
 That's it. Run `vite build` and your bundle is obfuscated. `vite dev` is left untouched so the dev experience stays normal.
 
-For Webpack / Rollup / esbuild / Next.js / Nuxt / SvelteKit / Astro / Solid / Qwik / React Router 7 / TanStack Router setups, see the **[full documentation](https://josedacosta.github.io/tailwindcss-obfuscator/)**.
+For Webpack / Rollup / esbuild / Rspack / Farm / Next.js / Nuxt / SvelteKit / Astro / Solid / Qwik / Vue / React Router 7 / TanStack Router setups, see the **[full documentation](https://josedacosta.github.io/tailwindcss-obfuscator/)**.
 
 ## Plugin entry points
 
@@ -68,6 +68,8 @@ For Webpack / Rollup / esbuild / Next.js / Nuxt / SvelteKit / Astro / Solid / Qw
 | Webpack             | `tailwindcss-obfuscator/webpack`   |
 | Rollup              | `tailwindcss-obfuscator/rollup`    |
 | esbuild             | `tailwindcss-obfuscator/esbuild`   |
+| Rspack              | `tailwindcss-obfuscator/rspack`    |
+| Farm                | `tailwindcss-obfuscator/farm`      |
 | Nuxt module         | `tailwindcss-obfuscator/nuxt`      |
 | CLI binary          | `tw-obfuscator` (after install)    |
 | Internal pipeline   | `tailwindcss-obfuscator/internals` |
@@ -81,6 +83,8 @@ For Webpack / Rollup / esbuild / Next.js / Nuxt / SvelteKit / Astro / Solid / Qw
 | **Webpack**         | v5            |
 | **Rollup**          | v3 → v4       |
 | **esbuild**         | ≥ 0.17        |
+| **Rspack**          | v1+           |
+| **Farm**            | v1+           |
 | **Next.js**         | v13 → v16     |
 | **Nuxt**            | v3 · v4       |
 | **SvelteKit**       | v2            |


### PR DESCRIPTION
## Summary

A targeted pass on inaccuracies surfaced by an audit of `README.md`, `packages/tailwindcss-obfuscator/README.md`, and `docs/`. All findings are factual fixes (no rewrites, no scope creep), grouped here for one easy review.

### Critical
- **docs/index.md L18** — typo in the GitHub CTA URL (`tailwindcss-obfuscation` → `tailwindcss-obfuscator`). The "View on GitHub" button on the homepage was 404.

### Comparison table
- "All five" → "All six" — we extract six class utilities (`cn`, `clsx`, `classnames`, `twMerge`, `cva`, `tv`).
- "13+ apps" → "20+ apps" — the actual sample-app count.
- `tailwindcss-mangle` Tailwind v4 cell — flipped from "⚖ Partial" to "✓ via CSS scanning (v9.0.0+)" after re-downloading and inspecting the v9.0.0 sources.
- New NOTE callout under the table clarifying the goal difference (mangling vs. obfuscation), so the comparison stays honest.

### Bundlers
- `README.md` and `packages/.../README.md` now mention **Rspack** and **Farm** in the framework lists. The plugins themselves arrive in the parallel PR (#4).

### Sidebar
- `docs/.vitepress/config.ts` — Maintainers' Checklist (`docs/maintainers.md`) is now reachable from the sidebar instead of being an orphan page.

### Research pages
- `docs/research/ecosystem.md`, `docs/research/lab_tailwindcss_patch_analysis.md`, `docs/research/tailwindcss-patch.md`, `docs/research/v4-issues.md` — refreshed against the freshly re-downloaded `sonofmagic/tailwindcss-mangle@v9.0.0` sources. Pages now clearly separate "this is what was true for v8.x" from "v9.0.0 changed the picture by switching to CSS scanning" + add a "Why we still differ" subsection (we obfuscate, they mangle for tree-shaking).

## Test plan

- [x] `pnpm format:check` clean
- [x] `pnpm lint` clean
- [ ] Local `pnpm docs:dev` walk — every link in the sidebar resolves; Maintainers page is now visible