### PR TITLE
docs: SEO & GEO optimization (Keywords + expanded FAQ + llms.txt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,41 @@ Official logos for your projects, articles, and presentations:
 ## ❓ FAQ
 
 <details>
+<summary><strong>🤔 &nbsp; What is a Tailwind CSS obfuscator?</strong></summary>
+
+A Tailwind CSS obfuscator (also called a **Tailwind class mangler**) is a build-time tool that rewrites verbose utility class names like `bg-blue-500`, `flex`, `items-center` into short opaque identifiers like `tw-a`, `tw-b`, `tw-c` inside the shipped HTML / CSS / JS bundle. Source code stays readable — only production output is changed. The result: smaller CSS, harder-to-reverse-engineer design system, zero runtime cost.
+
+</details>
+
+<details>
+<summary><strong>📉 &nbsp; How much does it shrink my CSS bundle?</strong></summary>
+
+Typical savings on production builds (gzip): **30–60%** on CSS-heavy pages. Marketing sites and shadcn/ui dashboards usually see the biggest gains because they ship many long compound class names. See the [Performance impact](#-performance-impact) table above for measurements on the 14 included test apps.
+
+</details>
+
+<details>
+<summary><strong>🆚 &nbsp; How is this different from <code>tailwindcss-mangle</code>?</strong></summary>
+
+`tailwindcss-mangle` was built primarily to **mangle Tailwind classes for tree-shaking and dead-class removal**. `tailwindcss-obfuscator` is built around **obfuscation as the primary goal**: a unified `unplugin` core (Vite/Webpack/Rollup/esbuild/Rspack/Farm), AST-based JSX/TSX extraction with full `cn() / clsx() / cva() / tv()` support, native Svelte `class:` directives, source maps, a standalone CLI, and an explicit Tailwind v4 path. See the [comparison](#-why-this-library) table.
+
+</details>
+
+<details>
+<summary><strong>🆕 &nbsp; Does it work with Tailwind CSS v4?</strong></summary>
+
+Yes — full v4 support, including `@import "tailwindcss"`, `@theme`, container queries (`@container`, `@lg:`), `@starting-style`, the `*:` / `**:` wildcard selectors, and the new `bg-(--my-var)` CSS-variable shorthand. v3 is also fully supported (config file, JIT, `safelist`, custom variants).
+
+</details>
+
+<details>
+<summary><strong>⚛️ &nbsp; Does it work with Next.js / Nuxt / SvelteKit / Astro / Solid / Qwik / Remix?</strong></summary>
+
+Yes — every major meta-framework is supported and has a dedicated test app under [`apps/`](./apps/): Next.js (App Router + Pages Router), Nuxt 4, SvelteKit + Svelte 5, Astro 6, Solid.js 1.9, Qwik 1.19, React Router v7 (ex-Remix), TanStack Start. Use the matching plugin entry from the [Quick Start](#-quick-start) section.
+
+</details>
+
+<details>
 <summary><strong>🤔 &nbsp; Will obfuscation break my dev server?</strong></summary>
 
 No — obfuscation is **disabled in development by default**. It only runs when `command === "build"` (Vite) or `mode === "production"` (Webpack/Next.js). Set `refresh: true` if you want it on in dev too.
@@ -835,9 +870,30 @@ tailwindCssObfuscatorVite({
 </details>
 
 <details>
-<summary><strong>🆕 &nbsp; Does it work with Tailwind v4?</strong></summary>
+<summary><strong>🧱 &nbsp; Does it work with shadcn/ui, CVA and Tailwind Variants?</strong></summary>
 
-Yes — full v4 support, including `@theme`, container queries, `@starting-style`, the `*:` / `**:` wildcard selectors, and the new `bg-(--my-var)` CSS-variable shorthand.
+Yes — the AST extractor recognises `cn()`, `clsx()`, `classnames()`, `twMerge()`, `cva()` and `tv()` natively, including string literals nested inside `variants`, `compoundVariants` and `defaultVariants`. The dedicated [`apps/test-shadcn-ui`](./apps/test-shadcn-ui) sample app exercises the full shadcn/ui + CVA pattern under production build.
+
+</details>
+
+<details>
+<summary><strong>🔄 &nbsp; Is the transformation reversible? Can I deobfuscate later?</strong></summary>
+
+Yes — every build emits `.tw-obfuscation/class-mapping.json`, a deterministic `original → obfuscated` mapping. Keep it under version control (or in your CI artefacts) and you can translate any `tw-xxx` back to its original class for debugging, error reporting, or post-hoc analytics.
+
+</details>
+
+<details>
+<summary><strong>🛡️ &nbsp; Is class obfuscation enough to "protect" my design system?</strong></summary>
+
+Obfuscation makes reverse-engineering **significantly harder** but it is not encryption — anyone can still read the rendered output. Combined with HTML minification, source-map omission, and a tight `preserve.classes` list, it raises the cost of "copy this site's design tokens" from minutes to hours. Treat it as one layer of defence, not a guarantee.
+
+</details>
+
+<details>
+<summary><strong>⚠️ &nbsp; Why are my dynamic classes not being obfuscated?</strong></summary>
+
+Because they are not visible to the AST scanner at build time. Patterns like ``className={`bg-${color}-500`}`` are constructed at runtime — the obfuscator never sees the final string. Switch to a static ternary (`color === "red" ? "bg-red-500" : "bg-blue-500"`) or a `cn()` call with all branches spelled out. See the [Static Classes Only](#️-important-static-classes-only) section.
 
 </details>
 
@@ -852,6 +908,13 @@ import { obfuscatorUnplugin } from "tailwindcss-obfuscator/internals";
 ```
 
 Or use the standalone CLI as a post-build step.
+
+</details>
+
+<details>
+<summary><strong>🆓 &nbsp; Is it free? What's the licence?</strong></summary>
+
+Yes — **MIT licensed**, free for personal, commercial, and closed-source use. If it ships in your production bundle, a star or a [GitHub Sponsorship](https://github.com/sponsors/josedacosta) is the kindest way to say thanks.
 
 </details>
 
@@ -881,6 +944,47 @@ Built and maintained by **José DA COSTA**.
 </table>
 
 If `tailwindcss-obfuscator` ships in your production bundle, a star or a sponsorship is the kindest way to say thanks.
+
+<!-- ────────────────────────────────────────────────── -->
+
+## 🔎 Keywords & search terms
+
+<details>
+<summary><strong>🔍 &nbsp; What people search for when they need this library</strong></summary>
+
+<br />
+
+If a search engine or LLM brought you here, here are the queries this project answers. Use them to verify it fits your use case — and to help others find it.
+
+**Core intent**
+
+`tailwindcss obfuscator` · `tailwind css obfuscator` · `tailwind obfuscator` · `obfuscate tailwind classes` · `obfuscate tailwind css` · `tailwind class obfuscation` · `obfuscate tailwind utility classes` · `hide tailwind classes` · `protect tailwind design system` · `tailwind reverse engineering protection` · `make tailwind classes unreadable`
+
+**Mangling alternatives**
+
+`tailwind mangle` · `tailwindcss mangle` · `tailwind class mangler` · `tailwindcss-mangle alternative` · `unplugin-tailwindcss-mangle alternative` · `tailwindcss-patch alternative` · `tailwindcss-mangle vs obfuscator` · `tailwindcss-mangle tailwind v4`
+
+**Bundle size**
+
+`shrink tailwind css bundle` · `reduce tailwind css size` · `tailwind css minifier` · `tailwind class shortener` · `smaller tailwind bundle` · `tailwind css bundle 30%` · `tailwind css bundle 50%` · `optimize tailwind css production`
+
+**Bundlers**
+
+`tailwind vite plugin obfuscate` · `tailwind webpack plugin obfuscate` · `tailwind rollup plugin obfuscate` · `tailwind esbuild plugin obfuscate` · `tailwind rspack plugin` · `tailwind farm plugin` · `unplugin tailwind obfuscator`
+
+**Frameworks**
+
+`next.js tailwind obfuscator` · `next.js tailwind mangle` · `nuxt tailwind obfuscator` · `nuxt module tailwindcss obfuscator` · `sveltekit tailwind obfuscator` · `astro tailwind obfuscator` · `solid.js tailwind obfuscator` · `qwik tailwind obfuscator` · `react router tailwind obfuscator` · `tanstack router tailwind obfuscator` · `remix tailwind obfuscator` · `shadcn ui obfuscate` · `cva obfuscate` · `tailwind variants obfuscate`
+
+**Tailwind versions**
+
+`tailwind v3 obfuscator` · `tailwind v4 obfuscator` · `tailwind v4 mangle` · `tailwind v4 class shortener` · `tailwind v4 class obfuscation oxide` · `@tailwindcss/vite obfuscator` · `@tailwindcss/postcss obfuscator`
+
+**Use cases**
+
+`hide design tokens from competitors` · `obscure tailwind theme` · `prevent tailwind copy paste` · `protect css ip` · `tailwind class names production only` · `class mangling source maps`
+
+</details>
 
 <!-- ────────────────────────────────────────────────── -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,41 @@
 ---
 layout: home
+title: tailwindcss-obfuscator — Mangle, Obfuscate & Shrink Tailwind CSS Classes at Build Time
+description: Build-time Tailwind CSS class obfuscator (mangler) for Vite, Webpack, Rollup, esbuild, Next.js, Nuxt, SvelteKit, Astro, Solid, Qwik. Tailwind v3 & v4. Cuts CSS bundle size by 30–60% and protects your design system.
+head:
+  - - meta
+    - name: description
+      content: Build-time Tailwind CSS class obfuscator and mangler. Shrink your CSS bundle by 30–60% and protect your design system. Vite, Webpack, Rollup, esbuild, Next.js, Nuxt, SvelteKit, Astro, Solid, Qwik. Tailwind v3 & v4.
+  - - meta
+    - name: keywords
+      content: tailwindcss obfuscator, tailwind css obfuscator, tailwind mangle, tailwindcss-mangle, css class obfuscation, css minifier, css class shortener, tailwind v4, tailwind v3, vite plugin, webpack plugin, rollup plugin, esbuild plugin, next.js, nuxt, sveltekit, astro, solid, qwik, react router, tanstack router, shrink css, design system protection, reverse engineering protection
+  - - meta
+    - property: og:title
+      content: tailwindcss-obfuscator — Mangle & Shrink Tailwind CSS Classes
+  - - meta
+    - property: og:description
+      content: Cut your Tailwind CSS bundle by 30–60% at build time. Works with Vite, Webpack, Rollup, esbuild, Next.js, Nuxt, SvelteKit, Astro, Solid, Qwik. Tailwind v3 & v4.
+  - - meta
+    - property: og:type
+      content: website
+  - - meta
+    - property: og:url
+      content: https://josedacosta.github.io/tailwindcss-obfuscator/
+  - - meta
+    - property: og:image
+      content: https://josedacosta.github.io/tailwindcss-obfuscator/images/tailwindcss-obfuscator/logo-horizontal.svg
+  - - meta
+    - name: twitter:card
+      content: summary_large_image
+  - - meta
+    - name: twitter:title
+      content: tailwindcss-obfuscator — Mangle & Shrink Tailwind CSS Classes
+  - - meta
+    - name: twitter:description
+      content: Build-time Tailwind class obfuscator. Shrink CSS by 30–60%, protect your design system. Vite, Webpack, Rollup, esbuild, Next.js, Nuxt, SvelteKit, Astro, Solid, Qwik.
+  - - link
+    - rel: canonical
+      href: https://josedacosta.github.io/tailwindcss-obfuscator/
 
 hero:
   name: tailwindcss-obfuscator
@@ -15,7 +51,7 @@ hero:
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/josedacosta/tailwindcss-obfuscation
+      link: https://github.com/josedacosta/tailwindcss-obfuscator
 
 features:
   - icon:

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,61 @@
+# tailwindcss-obfuscator
+
+> Build-time Tailwind CSS class obfuscator (also known as a Tailwind class mangler). Rewrites verbose utility classes (`bg-blue-500`, `flex`, `items-center`) into short opaque identifiers (`tw-a`, `tw-b`, `tw-c`) inside the shipped HTML / CSS / JS bundle. Source code stays readable. Cuts CSS bundle size by 30–60% on CSS-heavy pages and makes design systems much harder to reverse-engineer. Works with Tailwind CSS v3 and v4, every major bundler (Vite, Webpack, Rollup, esbuild, Rspack, Farm) and every major framework (Next.js, Nuxt, SvelteKit, Astro, Solid, Qwik, React Router 7, TanStack Router).
+
+## What it does
+
+- Build-time only — runs during `vite build` / `next build` / `webpack --mode=production`. Dev servers are untouched.
+- Zero runtime overhead — no JavaScript is added to the shipped bundle, only the strings change.
+- AST-based — uses Babel for JSX/TSX, PostCSS for CSS, and dedicated parsers for Vue SFC / Svelte / Astro / HTML.
+- Unified `unplugin` core — one shared pipeline, six bundler adapters (Vite, Webpack, Rollup, esbuild, Rspack, Farm) plus a Nuxt module and a Node CLI binary (`tw-obfuscator`).
+- Recognises `cn()`, `clsx()`, `classnames()`, `twMerge()`, `cva()`, `tv()` out of the box.
+- Tailwind v3 (config-file, JIT) and Tailwind v4 (CSS-first, `@theme`, container queries, `@starting-style`, CSS variable shorthand) are both supported.
+- Persists a deterministic mapping at `.tw-obfuscation/class-mapping.json` so builds stay debuggable.
+
+## Install
+
+```bash
+pnpm add -D tailwindcss-obfuscator
+# or: npm install --save-dev tailwindcss-obfuscator
+# or: yarn add --dev tailwindcss-obfuscator
+# or: bun add -D tailwindcss-obfuscator
+```
+
+## Quick start (Vite)
+
+```ts
+import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
+import tailwindCssObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [tailwindcss(), tailwindCssObfuscator({ prefix: "tw-" })],
+});
+```
+
+## Documentation
+
+- Site: https://josedacosta.github.io/tailwindcss-obfuscator/
+- Repository: https://github.com/josedacosta/tailwindcss-obfuscator
+- npm: https://www.npmjs.com/package/tailwindcss-obfuscator
+- License: MIT
+- Author: José DA COSTA — https://www.josedacosta.info
+
+## Plugin entry points
+
+- `tailwindcss-obfuscator/vite` — Vite plugin
+- `tailwindcss-obfuscator/webpack` — Webpack plugin
+- `tailwindcss-obfuscator/rollup` — Rollup plugin
+- `tailwindcss-obfuscator/esbuild` — esbuild plugin
+- `tailwindcss-obfuscator/rspack` — Rspack plugin
+- `tailwindcss-obfuscator/farm` — Farm plugin
+- `tailwindcss-obfuscator/nuxt` — Nuxt module
+- `tailwindcss-obfuscator/internals` — `obfuscatorUnplugin` factory for any other bundler
+- `tw-obfuscator` — standalone CLI binary
+
+## Frequently asked
+
+- Is it different from tailwindcss-mangle? Yes — `tailwindcss-mangle` mangles class names for tree-shaking and dead-class removal; `tailwindcss-obfuscator` is built around obfuscation: short opaque identifiers, AST extraction across every modern framework, and a unified `unplugin` core.
+- Does it work with Tailwind v4? Yes, including `@theme`, container queries, `@starting-style`, the `*:` / `**:` wildcards, and the new `bg-(--my-var)` CSS-variable shorthand.
+- Does it break dev mode? No — obfuscation only runs on production builds by default.
+- Static classes only? Yes — classes must be complete string literals at build time. Dynamic interpolation (`` `bg-${color}-500` ``) is left alone.

--- a/packages/tailwindcss-obfuscator/README.md
+++ b/packages/tailwindcss-obfuscator/README.md
@@ -7,8 +7,9 @@
 <h1 align="center">tailwindcss-obfuscator</h1>
 
 <p align="center">
-  Obfuscate Tailwind CSS class names at build time —<br/>
-  Vite · Webpack · Rollup · esbuild · Next.js · Nuxt · SvelteKit · Astro · Solid · Qwik · React Router 7 · TanStack Router.<br/>
+  <strong>Obfuscate, mangle and shrink Tailwind CSS class names at build time.</strong><br/>
+  Cuts your CSS bundle by <strong>30–60%</strong> and protects your design system from copy-paste reverse-engineering.<br/>
+  Vite · Webpack · Rollup · esbuild · Rspack · Farm · Next.js · Nuxt · SvelteKit · Astro · Solid · Qwik · React Router 7 · TanStack Router.<br/>
   Tailwind <strong>v3</strong> &amp; <strong>v4</strong>.
 </p>
 
@@ -92,6 +93,73 @@ For Webpack / Rollup / esbuild / Next.js / Nuxt / SvelteKit / Astro / Solid / Qw
 | **React Router**    | v7 (ex-Remix) |
 | **TanStack Router** | v1.168+       |
 | **Node.js**         | ≥ 18          |
+
+## FAQ
+
+<details>
+<summary><strong>What is a Tailwind CSS obfuscator (a.k.a. Tailwind class mangler)?</strong></summary>
+
+A build-time tool that rewrites verbose Tailwind classes (`bg-blue-500`, `flex`, `items-center`) into short opaque identifiers (`tw-a`, `tw-b`, `tw-c`) inside the shipped HTML / CSS / JS bundle. Source code stays readable; only production output is changed. Net effect: **30–60% smaller CSS** and a **much harder-to-reverse-engineer** design system, with zero runtime cost.
+
+</details>
+
+<details>
+<summary><strong>How is it different from <code>tailwindcss-mangle</code>?</strong></summary>
+
+`tailwindcss-mangle` was built primarily to mangle classes for tree-shaking. `tailwindcss-obfuscator` is built around obfuscation as the primary goal: a unified `unplugin` core (Vite/Webpack/Rollup/esbuild/Rspack/Farm), AST extraction with full `cn() / clsx() / cva() / tv()` support, native Svelte `class:` directives, source maps, a standalone CLI (`tw-obfuscator`) and explicit Tailwind v4 support.
+
+</details>
+
+<details>
+<summary><strong>Does it work with Tailwind CSS v4?</strong></summary>
+
+Yes — full v4 support, including `@import "tailwindcss"`, `@theme`, container queries, `@starting-style`, the `*:` / `**:` wildcards, and the new `bg-(--my-var)` shorthand. v3 (config file, JIT, `safelist`) is also fully supported.
+
+</details>
+
+<details>
+<summary><strong>Does it work with Next.js / Nuxt / SvelteKit / Astro / Solid / Qwik / Remix?</strong></summary>
+
+Yes — every major meta-framework has a dedicated test app and a documented setup recipe. Use the matching plugin entry from the table above, or read the [framework guides](https://josedacosta.github.io/tailwindcss-obfuscator/).
+
+</details>
+
+<details>
+<summary><strong>Will it break my dev server?</strong></summary>
+
+No — obfuscation only runs on production builds (`vite build` / `next build` / `webpack --mode=production`). Dev servers stay untouched.
+
+</details>
+
+<details>
+<summary><strong>Is the transformation reversible?</strong></summary>
+
+Yes — every build emits `.tw-obfuscation/class-mapping.json`, a deterministic mapping you can keep around to translate any `tw-xxx` back to its original class.
+
+</details>
+
+<details>
+<summary><strong>Does it support shadcn/ui, CVA, Tailwind Variants?</strong></summary>
+
+Yes — `cn()`, `clsx()`, `classnames()`, `twMerge()`, `cva()` and `tv()` are recognised natively, including string literals nested inside `variants`, `compoundVariants` and `defaultVariants`.
+
+</details>
+
+<details>
+<summary><strong>What's the licence?</strong></summary>
+
+MIT — free for personal, commercial, and closed-source use.
+
+</details>
+
+## Keywords
+
+<details>
+<summary><strong>Search terms this project answers</strong></summary>
+
+`tailwindcss obfuscator` · `tailwind css obfuscator` · `tailwind mangle` · `tailwindcss-mangle alternative` · `obfuscate tailwind classes` · `tailwind class shortener` · `shrink tailwind css bundle` · `tailwind v4 obfuscator` · `tailwind v3 obfuscator` · `tailwind vite plugin obfuscate` · `tailwind webpack plugin obfuscate` · `tailwind rollup plugin obfuscate` · `tailwind esbuild plugin obfuscate` · `tailwind rspack plugin` · `tailwind farm plugin` · `next.js tailwind obfuscator` · `nuxt tailwindcss obfuscator` · `sveltekit tailwind obfuscator` · `astro tailwind obfuscator` · `solid.js tailwind obfuscator` · `qwik tailwind obfuscator` · `react router tailwind obfuscator` · `tanstack router tailwind obfuscator` · `remix tailwind obfuscator` · `shadcn ui obfuscate` · `cva obfuscate` · `protect tailwind design system` · `hide tailwind classes` · `tailwind reverse engineering protection`
+
+</details>
 
 ## Author
 


### PR DESCRIPTION
## Summary

Optimizes the project's discoverability on **Google search** and on **LLM-driven search** (ChatGPT, Perplexity, Claude, Gemini, Google AI Overviews) using current SEO + GEO best practices.

### Changes

- **Root `README.md`**
  - Expanded FAQ: 6 → 13 questions, each crafted around a real search intent (\"What is a Tailwind obfuscator?\", \"How is it different from tailwindcss-mangle?\", \"How much does it shrink my bundle?\", \"Does it work with Next.js / Nuxt / SvelteKit / Astro / Solid / Qwik / Remix?\", \"Does it work with Tailwind v4?\", \"Is it reversible?\", \"Does it support shadcn / CVA / TV?\", \"What's the licence?\", and more).
  - New compact **Keywords & search terms** section in a `<details>` block, grouped by intent: core, mangling alternatives, bundle size, bundlers, frameworks, Tailwind versions, use cases.

- **Package `README.md`** (`packages/tailwindcss-obfuscator/README.md`)
  - Tightened tagline: now leads with the value proposition (30–60 % bundle savings + design-system protection) and lists every supported bundler (incl. Rspack + Farm).
  - Added an 8-question FAQ aligned with the npm landing page.
  - Added a one-line **Keywords** block.

- **Docs site (`docs/index.md`)**
  - SEO frontmatter: page `title`, `description`, full `head:` block (`<meta name=\"description\">`, `<meta name=\"keywords\">`, Open Graph tags, Twitter card, canonical link).
  - Fixed the broken \"View on GitHub\" CTA URL (`tailwindcss-obfuscation` → `tailwindcss-obfuscator`).

- **`docs/public/llms.txt`** *(new)*
  - GEO best practice: a short, structured summary that AI crawlers (GPTBot, ClaudeBot, PerplexityBot, GoogleOther) can ingest directly. Includes the value prop, install commands, every plugin entry point, and answers to the most-asked questions.

### Why

GitHub repos rank in Google when their README contains the exact terms people search for. The FAQ format additionally surfaces in Google's *People also ask* and in LLM answers, because models extract Q&A pairs preferentially. The new `llms.txt` follows the emerging GEO convention for guiding generative engines to canonical content.

## Test plan

- [x] `pnpm format:check` — passes
- [ ] `pnpm docs:build` — verify the new `head:` meta block renders into the generated HTML and that no broken links are introduced
- [ ] After merge, verify `https://josedacosta.github.io/tailwindcss-obfuscator/llms.txt` returns 200 and serves the file as plain text
- [ ] After merge, view-source on the homepage should show the new `<meta name=\"description\">` and Open Graph tags