### PR TITLE
docs: add framework guides for Vue, Solid, Qwik, esbuild, Rspack, Farm

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -94,6 +94,9 @@ export default defineConfig({
           text: "Vite-based Frameworks",
           items: [
             { text: "Vite", link: "/guide/vite" },
+            { text: "Vue 3", link: "/guide/vue" },
+            { text: "Solid.js", link: "/guide/solid" },
+            { text: "Qwik", link: "/guide/qwik" },
             { text: "TanStack Router", link: "/guide/tanstack-router" },
           ],
         },
@@ -102,6 +105,9 @@ export default defineConfig({
           items: [
             { text: "Webpack", link: "/guide/webpack-standalone" },
             { text: "Rollup", link: "/guide/rollup-standalone" },
+            { text: "esbuild", link: "/guide/esbuild" },
+            { text: "Rspack", link: "/guide/rspack" },
+            { text: "Farm", link: "/guide/farm" },
           ],
         },
         {

--- a/docs/guide/esbuild.md
+++ b/docs/guide/esbuild.md
@@ -1,0 +1,114 @@
+---
+outline: deep
+---
+
+# esbuild (standalone)
+
+Use the `tailwindcss-obfuscator/esbuild` plugin in any esbuild script — no framework, no bundler chain, just esbuild's JS API or its CLI.
+
+## Quick start
+
+::: code-group
+
+```bash [npm]
+npm install -D tailwindcss-obfuscator esbuild
+```
+
+```bash [pnpm]
+pnpm add -D tailwindcss-obfuscator esbuild
+```
+
+```bash [yarn]
+yarn add -D tailwindcss-obfuscator esbuild
+```
+
+```bash [bun]
+bun add -D tailwindcss-obfuscator esbuild
+```
+
+:::
+
+```ts
+// build.ts
+import * as esbuild from "esbuild";
+import TailwindObfuscator from "tailwindcss-obfuscator/esbuild";
+
+await esbuild.build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  outdir: "dist",
+  plugins: [TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+::: tip
+esbuild only sees what's reachable from `entryPoints`. Make sure your CSS file is imported (or listed under `loader`) — otherwise the obfuscator has no CSS to rewrite.
+:::
+
+## Production configuration
+
+```ts
+TailwindObfuscator({
+  prefix: "tw-",
+  content: ["src/**/*.{html,js,jsx,ts,tsx}"],
+  css: ["src/**/*.css"],
+  preserve: { classes: ["dark", "light", "sr-only"] },
+  mapping: {
+    enabled: true,
+    file: ".tw-obfuscation/class-mapping.json",
+    pretty: 2,
+  },
+});
+```
+
+## Loading CSS in esbuild
+
+esbuild needs to know how to handle `.css` imports. Two common setups:
+
+### Inline CSS via `text` loader
+
+```ts
+await esbuild.build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  outdir: "dist",
+  loader: { ".css": "css" },
+  plugins: [TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+### CSS via PostCSS
+
+If you generate Tailwind via `@tailwindcss/postcss`, run PostCSS in a watch step before esbuild and feed the resulting `.css` to esbuild's input. The obfuscator then rewrites the compiled CSS along with the JS bundle.
+
+## Patterns the plugin handles
+
+| Pattern                                                         | Status                            |
+| --------------------------------------------------------------- | --------------------------------- |
+| `className="flex items-center"` in a `.tsx` entry               | ✅ JSX/TSX entries                |
+| `class="..."` in a static `.html` template processed by esbuild | ✅ HTML loader                    |
+| `cn("flex", isActive && "ring-2")`                              | ✅ AST extraction                 |
+| Imports of CSS files via `import "./styles.css"`                | ✅ obfuscated alongside JS        |
+| Dynamic interpolation (`` `bg-${color}-500` ``)                 | ❌ left as-is — switch to ternary |
+
+## Troubleshooting
+
+::: warning Watch mode
+If you use `esbuild.context()` for watch mode, the obfuscator runs on every rebuild. The `.tw-obfuscation/class-mapping.json` file is rewritten between runs — make sure your editor isn't holding a stale handle.
+:::
+
+::: tip Standalone CLI alternative
+If your build pipeline doesn't fit cleanly into esbuild's plugin API, you can run the post-build CLI instead:
+
+```bash
+npx tw-obfuscator run --build-dir dist
+```
+
+It scans the existing `dist/` output and rewrites everything in place.
+:::
+
+## See also
+
+- Sample app — [`apps/test-static-html`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-static-html) (esbuild + static HTML)
+- [Options reference](./options.md)
+- [Class utilities](./class-utilities.md)

--- a/docs/guide/farm.md
+++ b/docs/guide/farm.md
@@ -1,0 +1,81 @@
+---
+outline: deep
+---
+
+# Farm
+
+Use `tailwindcss-obfuscator/farm` in any [Farm](https://www.farmfe.org) project. Farm is a Rust-powered build tool with a Vite-compatible plugin system, so the configuration mirrors the Vite guide.
+
+## Quick start
+
+::: code-group
+
+```bash [npm]
+npm install -D tailwindcss-obfuscator @farmfe/core
+```
+
+```bash [pnpm]
+pnpm add -D tailwindcss-obfuscator @farmfe/core
+```
+
+```bash [yarn]
+yarn add -D tailwindcss-obfuscator @farmfe/core
+```
+
+```bash [bun]
+bun add -D tailwindcss-obfuscator @farmfe/core
+```
+
+:::
+
+```ts
+// farm.config.ts
+import { defineConfig } from "@farmfe/core";
+import TailwindObfuscator from "tailwindcss-obfuscator/farm";
+
+export default defineConfig({
+  plugins: [TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+::: tip
+Like the Vite plugin, the obfuscator only runs for production builds (`farm build`). The dev server (`farm`) is left untouched so the dev experience stays normal.
+:::
+
+## Production configuration
+
+Same options surface as the [Vite guide](./vite.md):
+
+```ts
+TailwindObfuscator({
+  prefix: "tw-",
+  content: ["src/**/*.{html,js,jsx,ts,tsx,vue,svelte}"],
+  css: ["src/**/*.css"],
+  preserve: { classes: ["dark", "light", "sr-only"] },
+  mapping: {
+    enabled: true,
+    file: ".tw-obfuscation/class-mapping.json",
+    pretty: 2,
+  },
+});
+```
+
+## Patterns the plugin handles
+
+Identical to Vite — see the [Vite guide](./vite.md) for the full table. The shared `unplugin` core means JSX/TSX, Vue, Svelte, Astro and HTML extractors all work the same way.
+
+## Troubleshooting
+
+::: info Farm-specific behaviour
+Farm's persistent cache may keep a stale obfuscation mapping between dev runs. If you start seeing inconsistent class names during development, delete `node_modules/.farm` (or run `farm --clean`) and rebuild.
+:::
+
+::: warning JS plugin overhead
+Farm distinguishes between Rust plugins and JavaScript plugins. `tailwindcss-obfuscator/farm` is a JS plugin (it builds on `unplugin`), so it runs in Node, not in the Rust core. This is a few milliseconds slower than a pure-Rust plugin per file but doesn't change the build output.
+:::
+
+## See also
+
+- [Vite guide](./vite.md) — shared options + behaviour
+- [Options reference](./options.md)
+- [Class utilities](./class-utilities.md)

--- a/docs/guide/qwik.md
+++ b/docs/guide/qwik.md
@@ -1,0 +1,85 @@
+---
+outline: deep
+---
+
+# Qwik (Vite)
+
+Setup for a standard **Qwik + Vite** project. Qwik uses `class` (not `className`) and has its own `class$` reactive primitive — both go through the JSX transformer.
+
+## Quick start
+
+::: code-group
+
+```bash [npm]
+npm install -D tailwindcss-obfuscator
+```
+
+```bash [pnpm]
+pnpm add -D tailwindcss-obfuscator
+```
+
+```bash [yarn]
+yarn add -D tailwindcss-obfuscator
+```
+
+```bash [bun]
+bun add -D tailwindcss-obfuscator
+```
+
+:::
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { qwikVite } from "@builder.io/qwik/optimizer";
+import tailwindcss from "@tailwindcss/vite";
+import TailwindObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [qwikVite(), tailwindcss(), TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+## Qwik City
+
+For a full Qwik City app (the meta-framework), wire the obfuscator after `qwikCity()`:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import { qwikCity } from "@builder.io/qwik-city/vite";
+import { qwikVite } from "@builder.io/qwik/optimizer";
+import tailwindcss from "@tailwindcss/vite";
+import TailwindObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [qwikCity(), qwikVite(), tailwindcss(), TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+## Qwik patterns the plugin handles
+
+| Pattern                                                | Status                                                |
+| ------------------------------------------------------ | ----------------------------------------------------- |
+| `<div class="flex items-center gap-2" />`              | ✅ Static string                                      |
+| `<div class={["flex", "items-center"]} />`             | ✅ Array of strings                                   |
+| `<div class={{ "bg-red-500": hasError.value }} />`     | ✅ Object syntax                                      |
+| `<div class$={() => useSignal().value && "ring-2"} />` | ✅ Reactive — string literals inside still obfuscated |
+| `<div class={\`bg-\${color}-500\`} />`                 | ❌ Dynamic interpolation — kept as-is                 |
+
+::: tip
+`class$()` is Qwik's lazy reactive class binding (the `$` suffix marks it as a serialised closure). The plugin reads the **string literals** inside the closure body at AST time and rewrites them; the reactivity at runtime is preserved.
+:::
+
+## Troubleshooting
+
+::: warning Pre-rendered SSR output
+Qwik produces server-rendered HTML at build time. If you see un-obfuscated classes in the rendered HTML, check that the plugin runs **after** `qwikVite()` and `qwikCity()` in the plugin array. Order matters because Qwik rewrites JSX into its own format first.
+:::
+
+## See also
+
+- Sample app — [`apps/test-qwik`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-qwik)
+- [Vite guide](./vite.md) for shared options
+- [Class utilities](./class-utilities.md)
+- [Options reference](./options.md)

--- a/docs/guide/rspack.md
+++ b/docs/guide/rspack.md
@@ -1,0 +1,108 @@
+---
+outline: deep
+---
+
+# Rspack (standalone)
+
+Use `tailwindcss-obfuscator/rspack` directly in any [Rspack](https://rspack.dev) project. The plugin shares the same `unplugin` core as the Vite/Webpack adapters, so options behave identically.
+
+## Quick start
+
+::: code-group
+
+```bash [npm]
+npm install -D tailwindcss-obfuscator @rspack/core
+```
+
+```bash [pnpm]
+pnpm add -D tailwindcss-obfuscator @rspack/core
+```
+
+```bash [yarn]
+yarn add -D tailwindcss-obfuscator @rspack/core
+```
+
+```bash [bun]
+bun add -D tailwindcss-obfuscator @rspack/core
+```
+
+:::
+
+```ts
+// rspack.config.ts
+import { defineConfig } from "@rspack/cli";
+import TailwindObfuscator from "tailwindcss-obfuscator/rspack";
+
+export default defineConfig({
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
+        use: [
+          "@rspack/plugin-css",
+          {
+            loader: "postcss-loader",
+            options: {
+              postcssOptions: { plugins: ["@tailwindcss/postcss"] },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+::: tip
+The plugin only runs for production builds (`rspack build`). Pass `refresh: true` if you need it active during `rspack serve` too.
+:::
+
+## Production configuration
+
+```ts
+TailwindObfuscator({
+  prefix: "tw-",
+  content: ["src/**/*.{html,js,jsx,ts,tsx}"],
+  css: ["src/**/*.css"],
+  preserve: { classes: ["no-obfuscate", "sr-only"] },
+  mapping: {
+    enabled: true,
+    file: ".tw-obfuscation/class-mapping.json",
+    pretty: 2,
+  },
+});
+```
+
+## Patterns the plugin handles
+
+| Pattern                                               | Status                            |
+| ----------------------------------------------------- | --------------------------------- |
+| `className="..."` in JSX/TSX                          | ✅ Babel AST extractor            |
+| `class="..."` in HTML / Vue / Svelte / Astro emitters | ✅ via the relevant loader        |
+| `cn() / clsx() / cva() / tv()`                        | ✅                                |
+| `class:directive` in `.svelte` files                  | ✅                                |
+| Dynamic interpolation (`` `bg-${color}-500` ``)       | ❌ left as-is — switch to ternary |
+
+## Migrating from Webpack
+
+`@rspack/core` aims for Webpack 5 compatibility, so the migration from `tailwindcss-obfuscator/webpack` is a one-line change:
+
+```diff
+- import TailwindObfuscator from "tailwindcss-obfuscator/webpack";
++ import TailwindObfuscator from "tailwindcss-obfuscator/rspack";
+```
+
+All options (`prefix`, `preserve`, `mapping`, `randomize`, `classGenerator`) carry over unchanged.
+
+## Troubleshooting
+
+::: warning Loader order
+Like with Webpack, the obfuscator's CSS loader needs to run **after** the Tailwind PostCSS pass — otherwise it scans un-emitted classes. Place the obfuscator's plugin entry at the end of the plugin array.
+:::
+
+## See also
+
+- [Webpack standalone guide](./webpack-standalone.md) — same options surface
+- [Options reference](./options.md)
+- [Class utilities](./class-utilities.md)

--- a/docs/guide/solid.md
+++ b/docs/guide/solid.md
@@ -1,0 +1,95 @@
+---
+outline: deep
+---
+
+# Solid.js (Vite)
+
+Setup for a standard **Vite + Solid** project. Solid uses JSX with `class` (not `className`); the plugin's JSX transformer handles both.
+
+## Quick start
+
+::: code-group
+
+```bash [npm]
+npm install -D tailwindcss-obfuscator
+```
+
+```bash [pnpm]
+pnpm add -D tailwindcss-obfuscator
+```
+
+```bash [yarn]
+yarn add -D tailwindcss-obfuscator
+```
+
+```bash [bun]
+bun add -D tailwindcss-obfuscator
+```
+
+:::
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import solid from "vite-plugin-solid";
+import tailwindcss from "@tailwindcss/vite";
+import TailwindObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [solid(), tailwindcss(), TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+## Solid patterns the plugin handles
+
+| Pattern                                                         | Status                  |
+| --------------------------------------------------------------- | ----------------------- |
+| `<div class="flex items-center gap-2" />`                       | ✅ Static string        |
+| `<div classList={{ 'bg-red-500': hasError() }} />`              | ✅ `classList` object   |
+| `<Dynamic class={isError() ? 'bg-red-500' : 'bg-green-500'} />` | ✅ Static ternary       |
+| `<div class={cn('flex', active() && 'ring-2')} />`              | ✅ via `cn()`           |
+| `<div class={\`bg-\${color}-500\`} />`                          | ❌ Dynamic — kept as-is |
+
+::: tip
+Solid's reactivity model means class strings are recomputed on signal change, but they're still **string literals at AST time** — the plugin sees and rewrites them at build time, not runtime. No special configuration needed.
+:::
+
+## SolidStart
+
+If you're using SolidStart (Solid's meta-framework), the same Vite plugin applies:
+
+```ts
+// app.config.ts
+import { defineConfig } from "@solidjs/start/config";
+import TailwindObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  vite: {
+    plugins: [TailwindObfuscator({ prefix: "tw-" })],
+  },
+});
+```
+
+The plugin only activates for the production build (`vinxi build`), not for `vinxi dev`.
+
+## Troubleshooting
+
+::: warning `classList` keys
+The keys of a `classList` object are **string literals** in the JSX — they get obfuscated. The values (truthy/falsy expressions) are left alone.
+
+```tsx
+// Source
+<div classList={{ "bg-red-500": hasError(), "p-4": true }} />
+
+// After obfuscation
+<div classList={{ "tw-a": hasError(), "tw-b": true }} />
+```
+
+:::
+
+## See also
+
+- Sample app — [`apps/test-solidjs`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-solidjs)
+- [Vite guide](./vite.md) for shared options
+- [Class utilities](./class-utilities.md)
+- [Options reference](./options.md)

--- a/docs/guide/vue.md
+++ b/docs/guide/vue.md
@@ -1,0 +1,124 @@
+---
+outline: deep
+---
+
+# Vue 3 (Vite)
+
+Setup for a standard **Vite + Vue 3** project. The plugin handles every class-bearing syntax Vue offers — `class="..."`, `:class="{ … }"`, `:class="[ … ]"`, dynamic ternaries, and computed strings — through the shared AST transformer.
+
+## Quick start
+
+::: code-group
+
+```bash [npm]
+npm install -D tailwindcss-obfuscator
+```
+
+```bash [pnpm]
+pnpm add -D tailwindcss-obfuscator
+```
+
+```bash [yarn]
+yarn add -D tailwindcss-obfuscator
+```
+
+```bash [bun]
+bun add -D tailwindcss-obfuscator
+```
+
+:::
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import tailwindcss from "@tailwindcss/vite";
+import TailwindObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [vue(), tailwindcss(), TailwindObfuscator({ prefix: "tw-" })],
+});
+```
+
+That's it. `vite build` produces an obfuscated bundle; `vite dev` is left untouched so the dev experience stays normal.
+
+## Production configuration
+
+```ts
+TailwindObfuscator({
+  prefix: "tw-",
+  // Vue 3 only — see "Scoped styles" below
+  ignoreVueScoped: true,
+  preserve: {
+    // Classes you reference outside `<template>` (e.g. injected by directives)
+    classes: ["v-enter-active", "v-leave-active"],
+  },
+  mapping: { enabled: true, pretty: 2 },
+});
+```
+
+## Vue patterns the plugin handles
+
+| Pattern                                                   | Status                             |
+| --------------------------------------------------------- | ---------------------------------- |
+| `class="flex items-center gap-2"`                         | ✅ Static string                   |
+| `:class="{ 'bg-red-500': hasError, 'opacity-50': busy }"` | ✅ Object syntax (keys obfuscated) |
+| `:class="[base, isActive && 'ring-2 ring-blue-500']"`     | ✅ Array syntax (each item)        |
+| `:class="[base, { 'opacity-50': busy }]"`                 | ✅ Mixed array + object            |
+| `:class="computedClasses"` (computed string)              | ✅ Resolved at AST time            |
+| `class="bg-${color}-500"` (string interpolation)          | ❌ Dynamic — kept as-is            |
+
+::: tip
+For dynamic class construction, switch to the static ternary form:
+
+```vue
+<!-- breaks obfuscation -->
+<div :class="`bg-${color}-500`" />
+
+<!-- works -->
+<div :class="color === 'red' ? 'bg-red-500' : 'bg-blue-500'" />
+```
+
+:::
+
+## Scoped styles
+
+Vue's `<style scoped>` adds `[data-v-xxxxxxxx]` attribute selectors to each rule. By default `ignoreVueScoped: true` keeps those scoped selectors intact (only the **class** part is obfuscated, not the `data-v-*` attribute):
+
+```css
+/* before */
+.button[data-v-7ba5bd90] {
+  /* … */
+}
+
+/* after */
+.tw-a[data-v-7ba5bd90] {
+  /* … */
+}
+```
+
+If you set `ignoreVueScoped: false`, the PostCSS pass strips the data-v selector entirely — only do this if you know your scoped styles aren't relied on.
+
+## Troubleshooting
+
+::: warning Class showing up unobfuscated in the runtime
+Vue keeps a copy of `class` and `:class` on the root vnode, then merges them. If you set both `class="…"` and `:class="…"` on the same element, both go through the obfuscator independently — no special handling needed.
+:::
+
+::: danger Vuetify / element-plus / shadcn-vue components
+Component libraries inject classes from their own runtime. Add their prefixes to `preserve.classes` (or use a regex in `exclude`):
+
+```ts
+TailwindObfuscator({
+  exclude: [/^v-/, /^el-/, /^ant-/],
+});
+```
+
+:::
+
+## See also
+
+- Sample app — [`apps/test-vite-vue`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-vite-vue)
+- [Vite guide](./vite.md) for shared options
+- [Class utilities](./class-utilities.md) — `cn()`, `clsx()`, `cva()` patterns
+- [Options reference](./options.md)


### PR DESCRIPTION
## Summary

Adds the six dedicated guide pages the README has been promising. Each one follows the same template:

- frontmatter (`outline: deep`)
- Quick start with a `[npm] [pnpm] [yarn] [bun]` code-group
- Production configuration
- Framework-specific patterns table (✅ / ❌)
- Troubleshooting callouts (`::: tip` / `::: warning` / `::: info`)
- See also links

### New pages

- **Vite-based** — `docs/guide/vue.md`, `docs/guide/solid.md`, `docs/guide/qwik.md`
- **Standalone bundlers** — `docs/guide/esbuild.md`, `docs/guide/rspack.md`, `docs/guide/farm.md`

### Sidebar wiring (`docs/.vitepress/config.ts`)

- Vue / Solid / Qwik added under \"Vite-based Frameworks\"
- esbuild / Rspack / Farm added under \"Bundlers (standalone)\"

## Test plan

- [x] `pnpm format:check` — passes
- [ ] `pnpm docs:build` — verify no broken links and that all six pages render correctly
- [ ] Local preview (`pnpm docs:dev`) — click every new sidebar entry, every \"See also\" link
- [ ] After merge: `curl -I https://josedacosta.github.io/tailwindcss-obfuscator/guide/{vue,solid,qwik,esbuild,rspack,farm}` returns 200