### PR TITLE
chore: relocate reverse-engineering refs to jose/github/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,7 +64,6 @@ docs/.vitepress/cache
 # --- Maintainer-only directories (not for public consumption) -------------
 jose/
 reports/
-github/
 
 # --- AI agent instruction files (kept local, not for public consumption) --
 # These three files must stay identical (project policy) and live in each

--- a/.prettierignore
+++ b/.prettierignore
@@ -30,9 +30,6 @@ yarn.lock
 *.min.js
 *.min.css
 
-# Reverse-engineering refs (read-only sources)
-github/
-
-# French-only directories (per CLAUDE.md)
+# Local-only directories (per CLAUDE.md) — includes jose/github/ reverse-engineering refs
 jose/
 reports/

--- a/docs/research/ecosystem.md
+++ b/docs/research/ecosystem.md
@@ -144,11 +144,11 @@ Understanding this ecosystem is crucial for our `tailwindcss-obfuscator` because
 We have downloaded the source code for analysis:
 
 ```
-./github/tailwindcss-mangle/packages/tailwindcss-patch/
-./github/tailwindcss-mangle/packages/unplugin-tailwindcss-mangle/
+./jose/github/tailwindcss-mangle/packages/tailwindcss-patch/
+./jose/github/tailwindcss-mangle/packages/unplugin-tailwindcss-mangle/
 ```
 
-See `./github/README.md` for download instructions.
+See `./jose/github/README.md` for download instructions (the `jose/` directory is gitignored — refresh with `pnpm dlx tsx jose/github/download_github_repositories.ts`).
 
 ## References
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,6 @@ export default tseslint.config(
       "**/out/**",
       "**/public/build/**",
       "jose/**",
-      "github/**",
       "reports/**",
       "docs/.vitepress/dist/**",
       "docs/.vitepress/cache/**",


### PR DESCRIPTION
## Summary

Consolidates the maintainer's local-only directories under \`./jose/\`. The reverse-engineering working directory \`./github/\` (which holds read-only clones of competitor source code used for analysis) is moved to \`./jose/github/\`.

Both the old and new paths are already gitignored, so this PR contains only the small set of metadata + doc references that pointed at the old location.

### Changes

- **\`.gitignore\`** — drop the standalone \`github/\` entry; \`jose/\` already covers the new location.
- **\`.prettierignore\`** — collapse the two separate entries into a single comment block for \`jose/\` + \`reports/\`.
- **\`eslint.config.js\`** — drop the \`github/**\` ignore pattern (now covered by \`jose/**\`).
- **\`docs/research/ecosystem.md\`** — update the documented clone path and the \`pnpm dlx tsx …\` script invocation.

The actual source clones were moved with \`mv\` on disk; git sees no rename because both source and destination are gitignored.

## Test plan

- [x] \`pnpm format:check\` — passes
- [x] \`pnpm lint\` — no issues
- [ ] Verify the documented \`pnpm dlx tsx jose/github/download_github_repositories.ts\` invocation still resolves cleanly on a fresh clone