### PR TITLE
ci(release): commit version-bump as maintainer, not github-actions[bot]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Make the version-bump commit + the GitHub release land under the maintainer's
+      # identity instead of the default `github-actions[bot]` author. Otherwise the
+      # bot accumulates in the GitHub "Contributors" panel on every release.
+      - name: Configure git as maintainer
+        run: |
+          git config --global user.name "José DA COSTA"
+          git config --global user.email "contact@josedacosta.info"
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
@@ -43,6 +51,10 @@ jobs:
           version: pnpm changeset version
           commit: "chore(release): version packages"
           title: "chore(release): version packages"
+          # Don't let the action overwrite the git user we configured above.
+          setupGitUser: false
+          # Have the action create the GitHub release under the maintainer's identity.
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Stop the Changesets release flow from credit-stealing the maintainer's contributions to \`github-actions[bot]\`.

### Why

Currently the bot opens the \`chore(release): version packages\` PR; when we squash-merge it, the resulting commit on \`main\` carries the bot as author — so it shows up in the GitHub **Contributors** panel and on every subsequent release.

### Changes to \`.github/workflows/release.yml\`

1. **New step \"Configure git as maintainer\"** runs immediately after \`actions/checkout\` and sets \`user.name\` / \`user.email\` to the maintainer's identity.
2. \`changesets/action@v1\` now receives:
   - \`setupGitUser: false\` — don't override the identity we just set
   - \`createGithubReleases: true\` — auto-create GitHub releases on publish (so we don't have to do it manually like for v2.0.0)

### What this does NOT do

It does **not** rewrite history. Past commits authored by the bot (notably \`0a44a16\` for v2.0.0) stay as-is — force-push to \`main\` is forbidden by branch protection. The bot remains in contributors for that one historic commit only.

## Test plan

- [x] \`pnpm format:check\` — passes
- [ ] After merge, the **next** release-PR opened by Changesets and its associated GitHub release will carry José DA COSTA as author.