### PR TITLE
fix(docs): remove unused defineConfig import after Mermaid switch

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,3 @@
-import { defineConfig } from "vitepress";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
 export default withMermaid({


### PR DESCRIPTION
Fix the lint failure from the post-merge CI run on #10 (`@typescript-eslint/no-unused-vars` on `defineConfig`). The Mermaid wiring switched the export from `defineConfig` to `withMermaid` but left the import dangling.