### PR TITLE
ci(security): exceptional OSS hardening — dual AI review + Scorecard + SBOM + auto release-notes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,36 +48,185 @@ reviews:
     - "!jose/**" # local-only maintainer notes (gitignored anyway)
     - "!reports/**" # local audit outputs (gitignored anyway)
 
+  # =========================================================================
+  # SECURITY-FIRST REVIEW POSTURE
+  # =========================================================================
+  # This is a public OSS package shipped on npm. Every PR (and especially
+  # external-fork PRs) must be reviewed with the assumption that the
+  # contributor MAY be hostile — supply-chain attacks via OSS dependencies
+  # have happened (event-stream, ua-parser-js, colors.js, xz). Treat this
+  # repo as a potential injection target, never as a safe space.
+  #
+  # The maintainer (@josedacosta) makes the final call; CodeRabbit's job is
+  # to surface every possible smell so the maintainer doesn't have to grep.
+  # =========================================================================
+
   path_instructions:
+    # ----- ALL FILES (global security pass on every PR) -----
+    - path: "**/*"
+      instructions: |
+        SECURITY-FIRST review on every change. For each diff, explicitly check
+        and flag the following classes of concern, even on tiny PRs:
+
+        1. **Code execution via untrusted input** — `eval()`, `Function()`,
+           `vm.runInNewContext`, `child_process.exec*` with non-literal args,
+           dynamic `require()` / `import()` whose argument depends on user
+           input or a network response, `unescape()` of remote data.
+        2. **Shell injection** — backticks, template literals or string
+           concatenation passed to `exec`, `execSync`, `spawn`, shell scripts.
+        3. **Network exfiltration** — any new fetch/http(s)/dns lookup, any
+           new outbound domain, any obfuscated URL (base64-encoded,
+           hex-encoded, char-code-built strings, URL split across constants),
+           any "telemetry" / "analytics" / "phone-home" code added to a
+           library that has none.
+        4. **Filesystem reach beyond the project root** — `../`-walking,
+           `os.homedir()`, `~`, reading `~/.ssh/`, `~/.aws/`, `~/.npmrc`,
+           `~/.config`, environment variables holding tokens
+           (`NPM_TOKEN`, `GITHUB_TOKEN`, `AWS_*`, `*_API_KEY`).
+        5. **Postinstall / lifecycle hooks** — any new `postinstall`,
+           `preinstall`, `install`, `prepare`, `prepublishOnly` script in
+           any `package.json`. These run on `npm install` of downstream
+           consumers — extremely high blast radius.
+        6. **New dependencies** — every added line in `package.json` /
+           `pnpm-lock.yaml`. Check the package's npm page (downloads,
+           maintainers, last update, GitHub stars). Flag typosquats
+           (`reqeust`, `axios-http`, `loadash`), namespace squats
+           (`@types/whatever-fake`), packages younger than 6 months without
+           a clear track record.
+        7. **Encoded payloads** — base64 / hex / unicode-escape / char-code
+           strings longer than ~40 chars without a documented reason. These
+           are the canonical hiding place for malicious payloads.
+        8. **Disabled checks** — any `// eslint-disable-next-line`,
+           `// @ts-ignore`, `// @ts-expect-error`, `if (process.env.CI)`
+           bypass, `--no-verify`, `skip` test markers. Each must have a
+           justification in the PR description.
+        9. **Workflow / CI permission grabs** — see `.github/workflows/**`
+           rule below.
+        10. **Author trust signals** — first-time contributor? Commit signed?
+            GitHub account age < 1 year? Few public repos? Note these
+            facts in the review summary so the maintainer can weight risk.
+
+        For every flagged item, post an inline comment with:
+        - the exact line(s) of concern,
+        - the attack class it could enable,
+        - whether the diff actually exploits it or just *could* in a future
+          change (severity gradient: "definitely malicious" >> "smells bad"
+          >> "lint-style nit").
+
     - path: "packages/tailwindcss-obfuscator/src/**"
       instructions: |
-        This is the published package source. Be strict on:
-        - Public API stability (types, function signatures, plugin entry points).
-        - Tailwind v3 + v4 compatibility.
-        - Whether a `.changeset/*.md` accompanies any user-facing change.
-        - Edge cases for AST extraction (Babel) and CSS transformation (PostCSS).
-        - That the change does not break `cn() / clsx() / cva() / tv()` recognition.
+        This is the **published package source**. Be paranoid:
+
+        - Every change here ships to thousands of downstream consumers via
+          npm. A backdoor in this code propagates to every project using the
+          obfuscator.
+        - Verify the change does not introduce ANY of the SECURITY classes
+          above. If it does and the change is necessary, demand explicit
+          maintainer sign-off in the PR description.
+        - Public API stability: types, function signatures, plugin entry
+          points must not break without a `major` Changeset bump.
+        - Tailwind v3 + v4 compatibility: any new code path must consider
+          both versions.
+        - AST extraction (Babel) + CSS transformation (PostCSS) edge cases.
+        - That the change does not break `cn() / clsx() / cva() / tv()`
+          recognition.
+        - A `.changeset/*.md` MUST accompany any user-facing change.
+
     - path: "packages/tailwindcss-obfuscator/tests/**"
       instructions: |
-        Verify new tests cover the intended behaviour and edge cases.
-        Flag any test that imports from `dist/` instead of `src/`.
+        - Verify new tests cover the intended behaviour AND adversarial cases
+          (malformed input, deeply nested patterns, very long class lists).
+        - Flag any test that imports from `dist/` instead of `src/` (means
+          the test is validating the wrong artefact).
+        - Flag any test that disables timeouts, mocks the file system in a
+          way that hides side effects, or writes to paths outside the
+          project tree.
+
+    - path: "**/package.json"
+      instructions: |
+        EVERY change to a package.json must be scrutinised:
+
+        - New dependency added? Verify the package on npm: download count,
+          maintainer reputation, last publish date, source repo link, open
+          issues with security tags. Flag anything fishy.
+        - New `scripts` entry, especially `postinstall` / `preinstall` /
+          `install` / `prepare` / `prepublishOnly`? These run on every
+          downstream `npm install` — flag in red unless the rationale is
+          documented in the PR description.
+        - Version bumps to existing deps: pin format change (e.g. `^1.0.0`
+          becoming `*` or `latest`)? Major bump? Flag.
+        - New `bin` entries, new `exports` paths? Confirm they are the
+          intended public API surface.
+        - `engines` relaxed? Could introduce env-specific bugs.
+
+    - path: "pnpm-lock.yaml"
+      instructions: |
+        - Spot-check NEW transitive deps that appeared in this lockfile diff
+          but are not declared in any `package.json`. These are the indirect
+          deps that get pulled in by direct ones — a classic supply-chain
+          attack vector.
+        - Flag any version of a popular package downgrading to a much older
+          version (could be a maintainer-takeover repackage trick).
+        - Resolved URLs pointing anywhere other than
+          `https://registry.npmjs.org/...` are highly suspicious.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        Workflow changes are EXTREMELY sensitive — they run with repo
+        secrets and can publish to npm. Flag any:
+
+        - Use of `pull_request_target` without an explicit comment
+          explaining why. This trigger gives the workflow access to the
+          base repo's secrets even on PRs from forks — the #1 vector for
+          GitHub Actions supply-chain attacks (see "pwn request" attacks).
+        - Missing `permissions:` block at job or workflow level (defaults
+          to `write-all` token — too broad).
+        - Use of unpinned third-party actions. The whitelist requires
+          `actions/*`, `pnpm/action-setup@*`, `changesets/action@*`,
+          `github/codeql-action/*` — anything else is REJECTED unless added
+          to the org-level allowlist first.
+        - Secret usage (`${{ secrets.* }}`) inside a step that uses
+          `pull_request_target` or any third-party action that hasn't been
+          audited.
+        - `actions/checkout@v4` with `ref: ${{ github.event.pull_request.head.sha }}`
+          combined with `pull_request_target` — pulls the attacker's code
+          into a privileged context. Never allowed without explicit reason.
+        - Shell scripts (`run: |`) that interpolate `${{ github.event.* }}`
+          values (PR title, branch name, body) directly into commands.
+          That's command injection via PR metadata.
+        - New workflow that runs on `issue_comment` and acts on
+          `/comment-trigger` style commands — make sure the trigger checks
+          the commenter's permissions.
+
+    - path: ".github/CODEOWNERS"
+      instructions: |
+        ANY change to CODEOWNERS is a privileged action. Flag if anyone
+        other than @josedacosta is added as a code owner — this would let
+        them satisfy the CODEOWNER review gate and bypass the maintainer.
+        Never approve such a change without explicit maintainer sign-off.
+
+    - path: "scripts/**"
+      instructions: |
+        Build / verification scripts. Flag the same SECURITY classes as
+        above — these scripts run with the maintainer's local creds and CI
+        secrets. Filesystem reach beyond the repo, network egress, and
+        shell injection are all HIGH severity here.
+
     - path: "docs/**"
       instructions: |
         Docs are deployed automatically to GitHub Pages on every merge.
-        Verify links resolve, code samples are syntactically valid for the framework
-        they target, and the `outline: deep` frontmatter is set on guide pages.
-    - path: ".github/workflows/**"
-      instructions: |
-        Workflow changes are sensitive. Flag any:
-        - Use of `pull_request_target` without explaining why (security implication).
-        - Missing `permissions:` block (defaults are too broad).
-        - Use of unpinned third-party actions (always pin to a SHA or major version).
-        - Secret usage that might leak in fork-triggered runs.
+        Verify links resolve, code samples are syntactically valid for the
+        framework they target, and the `outline: deep` frontmatter is set
+        on guide pages. Flag any `<script>` tag injected into Markdown
+        (VitePress allows it) that fetches from an external domain.
+
     - path: "apps/**"
       instructions: |
-        Sample apps are not published. Focus on whether the app correctly
-        demonstrates the obfuscator integration and whether `pnpm build` still
-        produces obfuscated output.
+        Sample apps are not published to npm. Focus on whether the app
+        correctly demonstrates the obfuscator integration and whether
+        `pnpm build` still produces obfuscated output. Still apply the
+        global SECURITY checks — sample apps run on the maintainer's
+        machine during integration tests.
 
   # Don't flood every PR with a checklist; only when truly relevant.
   tools:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,164 @@
+# Repository custom instructions for GitHub Copilot
+
+> Copilot reads this file (when **Settings → Code & automation → Copilot → Code review → "Use custom instructions when reviewing pull requests"** is ON) and applies it on every PR review on this repository.
+>
+> The maintainer (@josedacosta) is the sole CODEOWNER and the only person who can merge to `main` or publish to npm. Copilot's reviews here are **informational only** — they do **not** approve PRs and do **not** satisfy branch protection.
+
+---
+
+## Project context
+
+`tailwindcss-obfuscator` is a **public OSS package shipped on npm** that thousands of downstream projects install. Any malicious code merged into `main` propagates through `npm publish` to the entire downstream user base — this is a high-value supply-chain attack target. Treat **every** PR (especially fork PRs from external contributors) as a potential injection vector. The cost of a missed false-negative is much higher than the cost of a false-positive comment.
+
+## Review priorities, in order
+
+1. **Security & supply-chain integrity** (this section, exhaustive list below)
+2. **Public API stability** (no breaking change without `major` Changeset)
+3. **Tailwind v3 + v4 compatibility**
+4. **Test coverage and edge cases**
+5. **Documentation alignment**
+6. Cosmetic / style nits — last priority, only if items 1–5 are clean
+
+## SECURITY — patterns to flag on every PR
+
+For each diff, explicitly check and post inline comments for any of the following classes of concern. Always state the **file:line**, the **attack class**, and the **severity** (`critical` if it actively exploits, `high` if it could trivially be turned into one, `medium` for "suspicious", `low` for "smells off").
+
+### Code-execution sinks
+
+- `eval()`, `new Function()`, `vm.runInNewContext`, `vm.runInThisContext`
+- `child_process.exec*` / `child_process.spawn*` whose first argument is built from a non-literal value
+- `require()` / `import()` whose argument is computed at runtime from any data that crosses a network or filesystem boundary
+- `unescape()`, `decodeURIComponent()` followed by execution
+- Any code that downloads a payload at runtime and `eval`s it
+
+### Shell-injection vectors
+
+- Backticks, template literals, or string concatenation feeding a `child_process.exec*` call
+- Any new shell script that interpolates `$()` or `${}` from a value not under maintainer control
+- Use of `shell: true` in `child_process.spawn` with non-literal args
+
+### Network exfiltration / unsolicited egress
+
+- Any new outbound request (`fetch`, `http`, `https`, `axios`, `got`, `node-fetch`, raw `net.connect`, `dns.lookup` to a non-standard resolver) that wasn't there before
+- Any **obfuscated URL**: base64-encoded, hex-encoded, char-code-built strings, or URL split across constants and concatenated at runtime
+- Any "telemetry", "analytics", "phone-home", or "metrics" code added to a library that previously had none — `tailwindcss-obfuscator` does **not** ship telemetry; flag any addition as high severity
+- Any new domain in a fetch URL — list it explicitly so the maintainer can decide
+
+### Filesystem reach beyond the project root
+
+- `../`-walking, `path.resolve` with non-literal segments
+- Reads of `os.homedir()`, `~`, `~/.ssh/`, `~/.aws/`, `~/.npmrc`, `~/.config/`, `~/.gitconfig`
+- Reads of environment variables holding tokens: `NPM_TOKEN`, `GITHUB_TOKEN`, `GH_TOKEN`, `AWS_*`, `*_API_KEY`, `*_SECRET`, `OPENAI_*`, `ANTHROPIC_*`
+- Writes outside `cwd()` / the build output directory
+
+### npm lifecycle hooks (extreme blast radius)
+
+- ANY new `postinstall`, `preinstall`, `install`, `prepare`, `prepublishOnly`, `prepublish`, `prerestart`, `prestart` script in any `package.json` in the diff
+- These run on every downstream `npm install` of the package — flag in **critical** unless the rationale is documented in the PR body and reviewed by the maintainer
+
+### New dependencies
+
+For every new line in `package.json` `"dependencies"` or `"devDependencies"`:
+
+- Cross-check on npm: download count (< 10k/week → suspicious), maintainer reputation, last publish date, source repo link, total versions
+- **Typosquats**: `reqeust`, `axios-http`, `loadash`, `expreSs`, `react-domn`, `commandr`
+- **Namespace squats**: `@types/whatever-fake`, packages from unknown orgs imitating popular ones
+- **New packages** (< 6 months old, no clear track record) → flag medium
+- **Switched maintainers**: package recently changed owner → flag high
+- **Suspicious version pinning**: `^*`, `latest`, `>=0.0.0`, or downgrade to a much older version of an established package
+
+### Lockfile diff (`pnpm-lock.yaml`)
+
+- Any new transitive dep that doesn't trace back to a direct `package.json` change in the same PR — could be a poisoned transitive
+- Resolved URLs pointing anywhere other than `https://registry.npmjs.org/...` → critical
+- Versions of widely-used packages downgrading sharply → high
+
+### Encoded payloads in source
+
+- Base64 / hex / unicode-escape / `String.fromCharCode(...)` strings longer than ~40 characters without a documented purpose → high
+- Strings split across multiple constants then concatenated at runtime, especially if the result looks like a URL, command, or credential → high
+- Long opaque blobs in JSON files → flag for inspection
+
+### Disabled checks (smell)
+
+Each instance must have a justification in the PR body, otherwise flag medium:
+
+- `// eslint-disable-next-line` / `// eslint-disable` / `// eslint-disable-line`
+- `// @ts-ignore` / `// @ts-expect-error` / `// @ts-nocheck`
+- `it.skip(...)` / `describe.skip(...)` / `test.skip(...)` / `xit(...)`
+- `--no-verify` mentioned anywhere
+- `if (process.env.CI)` paths that bypass tests
+- Conditionals that hide branches from coverage tools
+
+### GitHub Actions / workflow changes (`.github/workflows/**`)
+
+These run with repository secrets and can publish to npm. Apply the strictest scrutiny:
+
+- Use of `pull_request_target` without an inline comment explaining why. This trigger gives the workflow access to repo secrets even on PRs from forks — the **#1 GitHub Actions supply-chain attack vector ("pwn requests")**
+- `actions/checkout@v4` with `ref: ${{ github.event.pull_request.head.sha }}` combined with `pull_request_target` — pulls untrusted code into a privileged context, **never allowed**
+- Missing `permissions:` block at job or workflow level (defaults to `write-all` token — too broad)
+- Use of unpinned third-party actions. The repo allowlist is currently: `actions/*`, `pnpm/action-setup@*`, `changesets/action@*`, `github/codeql-action/*` — anything else must be added to the allowlist via `gh api repos/.../actions/permissions/selected-actions` first
+- Secret usage (`${{ secrets.* }}`) inside any step that uses `pull_request_target` or any third-party action that hasn't been audited
+- Shell scripts (`run: |`) that interpolate `${{ github.event.pull_request.title }}`, `body`, `head_ref`, `head.label`, etc., directly into commands → command-injection via PR metadata
+- New workflow that runs on `issue_comment` and acts on slash-commands — make sure the trigger checks the commenter's role/permissions
+- Any change that grants a workflow `id-token: write` or `packages: write` without a documented use case (these can mint OIDC tokens to publish to npm or to other registries)
+
+### CODEOWNERS changes (`.github/CODEOWNERS`)
+
+ANY change to CODEOWNERS is a **privileged action**. Flag if anyone other than `@josedacosta` is added as a code owner — that would let them satisfy the CODEOWNER review gate and bypass the maintainer. **Never approve such a change without explicit maintainer sign-off in the PR body.**
+
+### Author trust signals (include in summary)
+
+When reviewing a PR from a non-maintainer, include in the high-level summary the following facts so the maintainer can weigh trust:
+
+- Is this the contributor's first PR on this repo? (yes/no)
+- GitHub account age (< 1 year is a yellow flag)
+- Number of public repos with > 5 stars (proxy for community standing)
+- Are commits signed (verified)? Unsigned commits are not a deal-breaker but worth noting
+- Any history of merged PRs in adjacent OSS projects?
+
+## Public API stability
+
+Any change in `packages/tailwindcss-obfuscator/src/**` to:
+
+- An exported function signature (parameters, return type)
+- An exported type or interface
+- The `package.json` `exports` field
+- The CLI command shape (`tw-obfuscator`)
+
+…requires either a `minor` or `major` Changeset. If the PR adds the change without an appropriate Changeset, post a comment requesting one.
+
+## Tailwind v3 + v4 compatibility
+
+Any new code path in `packages/tailwindcss-obfuscator/src/**` must consider both Tailwind versions. Flag if a change works only on v4 (or only on v3) without an explicit guard.
+
+## Test coverage
+
+For source changes in `packages/tailwindcss-obfuscator/src/**`:
+
+- Verify a corresponding test exists (or is added)
+- Verify the test imports from `src/`, not `dist/`
+- Suggest adversarial cases: malformed input, deeply nested patterns, very long class lists
+
+## Documentation
+
+For changes that touch user-facing behaviour, verify `docs/**` is updated (the relevant guide page, the options reference, the CHANGELOG entry via Changeset). Code samples in `docs/**` must be valid for the target framework.
+
+## What to skip
+
+Do NOT comment on:
+
+- Generated paths: `**/dist/**`, `**/.next/**`, `**/.nuxt/**`, `**/.svelte-kit/**`, `**/.astro/**`, `**/coverage/**`, `pnpm-lock.yaml` (except for the supply-chain checks above), `**/CHANGELOG.md` (auto-generated), `docs/.vitepress/dist/**`, `docs/.vitepress/cache/**`
+- Local-only directories: `jose/**`, `reports/**` (gitignored, never shipped)
+- Changesets entries (`.changeset/*.md`) — content is the contributor's choice
+
+## Tone and format
+
+- Be concrete: cite file:line, suggest the exact fix
+- Be calibrated: don't tag a typo as "critical"; don't bury a real injection vector under nits
+- Always provide the **summary first**, then inline comments. The summary must list the security-relevant findings up top, even if there are no other findings
+- French is acceptable in maintainer-facing comments (the maintainer is French) but English is preferred since the project is OSS-international
+
+## Final reminder
+
+Copilot does **not** decide whether the PR is merged. The maintainer reads your review, weighs it, and decides. Your value is signal: the more concrete and specific the smell, the easier it is for the maintainer to act. Vague reviews waste his time; missed injection vectors put thousands of downstream users at risk.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,69 @@
+# Configuration for auto-generated GitHub release notes.
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+#
+# Triggered when a release is created with `generate_release_notes: true`
+# (changesets/action does this when `createGithubReleases: true`, or
+# `gh release create --generate-notes`).
+#
+# Categorises every merged PR since the last tag into the right section
+# based on its labels (set automatically by .github/workflows/labeler.yml).
+
+changelog:
+  exclude:
+    labels:
+      - "changeset" # the version bump PR itself, never interesting
+      - "chore"
+      - "duplicate"
+      - "wontfix"
+      - "invalid"
+    authors:
+      - "github-actions[bot]" # bot-authored PRs (e.g. release version bumps)
+
+  categories:
+    - title: "💥 Breaking changes"
+      labels:
+        - "breaking-change"
+    - title: "🚀 New features"
+      labels:
+        - "enhancement"
+        - "area: package"
+    - title: "🐛 Bug fixes"
+      labels:
+        - "bug"
+    - title: "🔒 Security"
+      labels:
+        - "security"
+    - title: "⚡ Performance"
+      labels:
+        - "performance"
+    - title: "📦 Bundlers"
+      labels:
+        - "framework: vite"
+        - "framework: webpack"
+        - "framework: rollup"
+        - "framework: esbuild"
+        - "framework: rspack"
+        - "framework: farm"
+    - title: "🧩 Frameworks"
+      labels:
+        - "framework: nextjs"
+        - "framework: nuxt"
+        - "framework: sveltekit"
+        - "framework: astro"
+        - "framework: solid"
+        - "framework: qwik"
+        - "framework: vue"
+    - title: "📚 Documentation"
+      labels:
+        - "area: docs"
+        - "documentation"
+    - title: "🧪 Tests"
+      labels:
+        - "area: tests"
+    - title: "👷 CI / build"
+      labels:
+        - "area: ci"
+        - "area: build"
+    - title: "🔧 Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,36 @@
+name: SBOM (Software Bill of Materials)
+
+# Generates an SBOM in SPDX format on every published GitHub release and
+# attaches it as a release asset. Downstream consumers can verify the exact
+# tree of dependencies that shipped with each version — supply-chain
+# transparency, OpenSSF Scorecard prerequisite.
+#
+# Triggered when a release is published (typically by changesets/action
+# during the release workflow), or manually for backfill.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write # to upload SBOM as a release asset
+
+jobs:
+  generate:
+    name: Generate SPDX SBOM and attach to release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo at release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+
+      - name: Generate SBOM with anchore/sbom-action (Syft)
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./packages/tailwindcss-obfuscator
+          format: spdx-json
+          output-file: tailwindcss-obfuscator.spdx.json
+          upload-artifact: true
+          upload-release-assets: true # attaches to the GitHub release

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: OpenSSF Scorecard
+
+# Audit the repo's security posture against the OpenSSF Scorecard checks
+# (branch protection, signed releases, pinned dependencies, code review,
+# token permissions, etc.). Free for public repos.
+#
+# Results land in:
+#   - the Security tab → Code scanning (as SARIF alerts)
+#   - the OpenSSF Scorecard public dashboard at scorecard.dev
+#   - the badge that we'll add to the README
+#
+# Runs weekly + on push to main + on demand.
+
+on:
+  branch_protection_rule: # re-audits when protection rules change
+  schedule:
+    - cron: "0 6 * * 1" # every Monday at 06:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # required for uploading SARIF results
+      security-events: write
+      # required to read the actions metadata
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true # opt-in: publishes the score to the public scorecard.dev dashboard
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning dashboard
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@
   </a>
 </p>
 
+<!-- Badges row 4 — security & supply chain -->
+<p>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/josedacosta/tailwindcss-obfuscator">
+    <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/josedacosta/tailwindcss-obfuscator?style=for-the-badge&label=OpenSSF%20Scorecard&color=10b981&labelColor=000000">
+  </a>
+  <a href="https://github.com/josedacosta/tailwindcss-obfuscator/security">
+    <img alt="CodeQL" src="https://img.shields.io/badge/CodeQL-active-10b981?style=for-the-badge&logo=github&logoColor=white&labelColor=000000">
+  </a>
+  <a href="https://www.npmjs.com/package/tailwindcss-obfuscator">
+    <img alt="npm provenance" src="https://img.shields.io/badge/npm-provenance-cb3837?style=for-the-badge&logo=npm&logoColor=white&labelColor=000000">
+  </a>
+</p>
+
 <br />
 
 <p>


### PR DESCRIPTION
## Summary

Wires the remaining best-practices for a public OSS package shipped to npm. Every change here is **gratuit**, **comment-only on the AI side**, and **complements (never bypasses) the maintainer's CODEOWNER review**.

## What lands

### New files

- **\`.github/copilot-instructions.md\`** — repository custom instructions for GitHub Copilot Code Review (now enabled via a ruleset on the default branch). Mirrors the security-paranoid posture of \`.coderabbit.yaml\`: explicit lists of code-execution sinks, shell-injection vectors, network-egress flags, npm lifecycle-hook traps, lockfile poisoning patterns, encoded payloads, disabled-check smells, GitHub Actions \"pwn request\" patterns, CODEOWNERS tampering detection, and contributor-trust signals.
- **\`.github/release.yml\`** — GitHub auto-generated release notes config. Categorises every merged PR into 10 sections (💥 Breaking / 🚀 Features / 🐛 Fixes / 🔒 Security / ⚡ Perf / 📦 Bundlers / 🧩 Frameworks / 📚 Docs / 🧪 Tests / 👷 CI / 🔧 Other) based on the labels assigned by \`.github/workflows/labeler.yml\`.
- **\`.github/workflows/scorecard.yml\`** — OpenSSF Scorecard analysis. Runs weekly + on push to main + on demand. Publishes to <https://scorecard.dev/viewer/?uri=github.com/josedacosta/tailwindcss-obfuscator> and uploads SARIF to the Security tab.
- **\`.github/workflows/sbom.yml\`** — generates an SPDX-JSON SBOM via anchore/sbom-action on every published GitHub release and attaches it as a release asset.

### Updates

- **\`.coderabbit.yaml\`** — radically tightened with a new global \`**/*\` rule listing 10 classes of security smells to flag on EVERY diff. Dedicated rules for \`**/package.json\`, \`pnpm-lock.yaml\`, \`.github/CODEOWNERS\`, \`scripts/**\`.
- **\`README.md\`** — new \"Security & supply chain\" badge row: OpenSSF Scorecard, CodeQL active, npm provenance.

### Repo settings already applied (via gh API + browser, documented in \`jose/scripts/github/\`)

- \`default_workflow_permissions: read\` (was write)
- \`can_approve_pull_request_reviews: false\` (was true)
- Fork PR approval: \"Require approval for ALL external contributors\" (was first-time only)
- Copilot Code Review ruleset on main
- CodeQL extended from \`actions\` only → \`actions\` + \`javascript-typescript\`

## Net effect

Every PR (especially from forks) now passes through:
- CI (lint, typecheck, tests, build) — **blocking**
- CodeQL (JS/TS + actions) — **blocking via Code scanning ruleset**
- CodeRabbit AI review (security-paranoid) — **comment-only**
- GitHub Copilot Code Review (security-paranoid via .github/copilot-instructions.md) — **comment-only**
- Maintainer review (CODEOWNER) — **only path to merge**

Every release publish is preceded by:
- npm provenance (OIDC-signed)
- SBOM artifact attached to the GitHub release
- Auto-categorised release notes

## Test plan

- [x] \`pnpm format:check\` — passes
- [ ] After merge, the OpenSSF Scorecard badge in README will render once the first scorecard.yml run completes (~5 min).
- [ ] CodeRabbit will start reviewing the next PR opened against \`main\`.
- [ ] Copilot Code Review will trigger automatically per the ruleset.