### PR TITLE
chore: add changeset for v2.0.1 (docs + CI/security overhaul, no runtime change)

### DIFF
--- a/.changeset/v2.0.1-docs-and-ci-overhaul.md
+++ b/.changeset/v2.0.1-docs-and-ci-overhaul.md
@@ -1,0 +1,38 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Documentation, CI, and contribution-workflow overhaul. No runtime change to the published package.
+
+**Documentation**
+
+- New dedicated framework guides for Vue 3, Solid.js, Qwik, esbuild, Rspack, Farm.
+- New "Full comparison" page benchmarking `tailwindcss-obfuscator` against `tailwindcss-mangle`, Obfustail, and PostCSS minifiers.
+- VitePress site now ships a Mermaid plugin (real diagrams replace ASCII art in `research/ecosystem`).
+- Sidebar gets a cross-section navigation block on every page; homepage "Get Started" CTA is visually scaled up.
+- Root README revamped: live-doc links instead of source paths, FAQ split into a search-intent section + a general/technical section, much-larger Contributing section, npm badges adapted for fresh-package state.
+- New `docs/public/llms.txt` for GEO (Generative Engine Optimization).
+- SEO `head:` meta block on the docs homepage (description, keywords, Open Graph, Twitter card, canonical).
+
+**CI / supply chain**
+
+- New `.github/workflows/scorecard.yml` — OpenSSF Scorecard analysis (weekly + on push).
+- New `.github/workflows/sbom.yml` — SPDX-JSON SBOM generated and attached to every GitHub release via anchore/sbom-action.
+- New `.github/workflows/labeler.yml` + `.github/labeler.yml` — auto-tags PRs with `area: …` / `framework: …` labels.
+- New `.github/workflows/welcome.yml` — first-time contributor greeting via actions/first-interaction.
+- New `.github/release.yml` — auto-categorised GitHub release notes from PR labels.
+- 31 standardised triage labels created via `gh label create`.
+- Default workflow GITHUB_TOKEN permissions tightened to `read` (was `write`); workflows can no longer self-approve PRs.
+- CodeQL default setup extended from `actions` only → `actions` + `javascript-typescript`.
+- Fork PR workflow approval set to "Require approval for ALL external contributors" (most strict).
+- Actions allowlist updated to include `ossf/scorecard-action@*` and `anchore/sbom-action@*`.
+
+**Automated review (informational only — never approves a PR)**
+
+- CodeRabbit GitHub App installed under the free Open Source plan, scoped to this repo only, configured via `.coderabbit.yaml` with security-paranoid review instructions.
+- GitHub Copilot Code Review enabled via a repository ruleset on the default branch, configured via `.github/copilot-instructions.md` with matching security-paranoid instructions.
+
+**Contribution workflow**
+
+- `CONTRIBUTING.md` made explicit about the dual standard (owner-streamlined vs external-strict), realistic review/release cadence, and the automated review tooling.
+- `.github/PULL_REQUEST_TEMPLATE.md` opens with a banner reminding contributors that only the maintainer can merge and that opening a PR doesn't trigger an npm publish.


### PR DESCRIPTION
## Summary

Adds a single \`patch\` Changeset entry that captures every user-visible change shipped since v2.0.0:

- New framework guides (Vue, Solid, Qwik, esbuild, Rspack, Farm)
- New \"Full comparison\" research page
- VitePress Mermaid plugin + sidebar cross-section nav + bigger Get Started CTA
- Root README revamp (live-doc links, FAQ split into search-intent + general, much-larger Contributing section, fresh-package npm badges)
- New \`docs/public/llms.txt\` for GEO
- SEO meta block on docs homepage
- OpenSSF Scorecard + SBOM workflows
- Auto-labeler + welcome bot + auto-generated release notes
- 31 standardised triage labels
- Workflow GITHUB_TOKEN tightened to read-only; workflows can't self-approve PRs
- CodeQL extended to JavaScript/TypeScript
- Fork PR workflow approval set to most-strict
- CodeRabbit GitHub App installed (security-paranoid config) + Copilot Code Review enabled
- CONTRIBUTING.md and PR template updated to make the dual standard explicit

No source code change, no behaviour change, no API change. The README + CHANGELOG that downstream users see when browsing the package on npm is what changes.

## Test plan

After this merges, the Changesets bot will update the open \`chore(release): version packages\` PR. Merging that PR with \`--admin\` triggers the \`release.yml\` workflow which publishes \`tailwindcss-obfuscator@2.0.1\` to npm with provenance and creates a brand new GitHub Release at the tag \`v2.0.1\` (this is what restores the \"Releases\" page on GitHub after the v2.0.0 tag was permanently locked by Sigstore).