### PR TITLE
chore(pkg): cross-package-manager parity (npm / yarn / pnpm) — fix `./package.json` export + drop pnpm engine pin + sync CLI version

### DIFF
--- a/.changeset/cross-package-manager-parity.md
+++ b/.changeset/cross-package-manager-parity.md
@@ -1,0 +1,13 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Cross-package-manager parity (npm / yarn / pnpm) — fixes 2 silent bugs that broke downstream tooling on every PM equally.
+
+**`./package.json` is now exported.** Previously, downstream tools that read the package metadata via `require("tailwindcss-obfuscator/package.json")` (Vite, Webpack, esbuild bundle analysis, Next.js framework probes, IDE TS plugins) crashed with `ERR_PACKAGE_PATH_NOT_EXPORTED` on Node 20+. The `exports` map now declares `"./package.json": "./package.json"`.
+
+**`engines` no longer pins pnpm.** The published package previously declared `engines.pnpm: ">=9.0.0"`, which leaked the maintainer's local toolchain to consumers and triggered `EBADENGINE` warnings on `npm install` / `yarn add`. Only `engines.node: ">=18.0.0"` remains (and is the only legit constraint for a published library).
+
+**CLI version is now read from `package.json` at runtime.** `tw-obfuscator --version` was hardcoded to `1.0.0` and never updated. It now resolves the live version via `createRequire(import.meta.url)("../../package.json").version`, so it always matches the installed package.
+
+A new test file `tests/package-exports.test.ts` adds 19 regression guards (every plugin entry has ESM + CJS + types, every optional bundler peerDep is marked optional, `./package.json` is exported, `engines` contains only `node`) so these bugs cannot silently re-appear.

--- a/packages/tailwindcss-obfuscator/package.json
+++ b/packages/tailwindcss-obfuscator/package.json
@@ -66,7 +66,8 @@
       "types": "./dist/plugins/nuxt.d.ts",
       "import": "./dist/plugins/nuxt.js",
       "require": "./dist/plugins/nuxt.cjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "bin": {
     "tw-obfuscator": "./dist/cli/bin.js"
@@ -199,8 +200,7 @@
     "url": "https://github.com/sponsors/josedacosta"
   },
   "engines": {
-    "node": ">=18.0.0",
-    "pnpm": ">=9.0.0"
+    "node": ">=18.0.0"
   },
   "sideEffects": false
 }

--- a/packages/tailwindcss-obfuscator/src/cli/index.ts
+++ b/packages/tailwindcss-obfuscator/src/cli/index.ts
@@ -16,6 +16,7 @@
 import { Command } from "commander";
 import * as fs from "fs";
 import * as path from "path";
+import { createRequire } from "module";
 import pc from "picocolors";
 import type { ObfuscatorOptions } from "../core/types.js";
 import {
@@ -31,7 +32,17 @@ import { createLogger, logSummary } from "../utils/logger.js";
 import { extractClasses, extractFromCssFiles, getExtractionStats } from "../extractors/index.js";
 import { transformDirectory, transformFile } from "../transformers/index.js";
 
-const VERSION = "1.0.0";
+// Read the live package version at runtime so the CLI never drifts from the
+// published package.json. Resolves the package's own package.json from the
+// installed location (works under npm / yarn / pnpm / bun).
+const VERSION: string = (() => {
+  try {
+    const require = createRequire(import.meta.url);
+    return (require("../../package.json") as { version: string }).version;
+  } catch {
+    return "0.0.0-unknown";
+  }
+})();
 
 /**
  * Resolve options from CLI flags + an optional `--config` file.

--- a/packages/tailwindcss-obfuscator/tests/package-exports.test.ts
+++ b/packages/tailwindcss-obfuscator/tests/package-exports.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Cross-package-manager parity guards.
+ *
+ * Both regressions below are silent (TypeScript / pnpm dev workspace can mask them
+ * because the workspace package.json is reachable via the path). They only surface
+ * when the published tarball is consumed by an end-user via `npm install`,
+ * `yarn add`, or `pnpm add`. These tests run against the workspace package.json
+ * so they catch the bug at PR time rather than at npm-publish time.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const pkgPath = resolve(__dirname, "..", "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+describe("package.json — cross-package-manager parity", () => {
+  describe('"./package.json" must be in exports', () => {
+    it("exposes ./package.json so downstream tools can read package metadata", () => {
+      // Many bundlers (Vite, Webpack, esbuild), framework probes (Next.js,
+      // Nuxt), and IDE TS plugins do `require("tailwindcss-obfuscator/package.json")`
+      // to read the version / engines / exports. Without this entry, every
+      // such tool throws ERR_PACKAGE_PATH_NOT_EXPORTED on Node 20+.
+      expect(pkg.exports["./package.json"]).toBe("./package.json");
+    });
+  });
+
+  describe("engines must NOT pin a specific package manager", () => {
+    it('engines must contain ONLY "node" — no "pnpm", "yarn", "npm" pins', () => {
+      // Pinning a PM in engines (e.g. "pnpm": ">=9.0.0") leaks the maintainer's
+      // local toolchain to consumers and triggers `EBADENGINE` warnings on
+      // npm/yarn install. Only `engines.node` is acceptable for a published
+      // library.
+      const enginesKeys = Object.keys(pkg.engines || {});
+      expect(enginesKeys).toEqual(["node"]);
+    });
+  });
+
+  describe("every plugin entry has both ESM + CJS + types", () => {
+    const expectedEntries = [
+      ".",
+      "./internals",
+      "./webpack",
+      "./vite",
+      "./rollup",
+      "./esbuild",
+      "./rspack",
+      "./farm",
+      "./cli",
+      "./nuxt",
+    ];
+
+    it.each(expectedEntries)("entry %s exposes types + import + require", (entry) => {
+      const exp = pkg.exports[entry];
+      expect(exp).toBeTypeOf("object");
+      expect(exp.types, `${entry}.types is missing`).toMatch(/\.d\.ts$/);
+      expect(exp.import, `${entry}.import is missing or wrong ext`).toMatch(/\.js$/);
+      expect(exp.require, `${entry}.require is missing or wrong ext`).toMatch(/\.cjs$/);
+    });
+  });
+
+  describe("optional bundler peerDependencies", () => {
+    const optionalPeers = ["@farmfe/core", "@rspack/core", "esbuild", "rollup", "vite", "webpack"];
+
+    it.each(optionalPeers)("%s must be marked optional", (peer) => {
+      expect(
+        pkg.peerDependenciesMeta?.[peer]?.optional,
+        `${peer} must be optional so npm/yarn/pnpm don't error when the consumer doesn't install it`
+      ).toBe(true);
+    });
+
+    it("tailwindcss must NOT be marked optional (it's a hard requirement)", () => {
+      expect(pkg.peerDependencies.tailwindcss).toBeDefined();
+      expect(pkg.peerDependenciesMeta?.tailwindcss?.optional).not.toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Verified cross-PM parity (npm / yarn-classic / yarn-berry / pnpm) by sandbox-installing the currently-published v2.0.0 from the registry under each PM. **All three break in the same way** because of two silent bugs in the published \`package.json\`:

| Bug | Failure mode | Fix in this PR |
|---|---|---|
| \`./package.json\` not in \`exports\` | \`require(\"tailwindcss-obfuscator/package.json\")\` throws \`ERR_PACKAGE_PATH_NOT_EXPORTED\` on Node 20+ — affects Vite, Webpack, esbuild bundle analysis, Next.js framework probes, IDE TS plugins | Add \`\"./package.json\": \"./package.json\"\` to the exports map |
| \`engines.pnpm: \">=9.0.0\"\` in the published package | Triggers \`EBADENGINE\` warning on \`npm install\` and \`yarn add\`, leaks maintainer toolchain | Drop the \`pnpm\` field; keep only \`engines.node: \">=18.0.0\"\` |
| \`tw-obfuscator --version\` hardcoded to \`1.0.0\` | CLI reports the wrong version regardless of installed package | Resolve via \`createRequire(import.meta.url)(\"../../package.json\").version\` at runtime |

## Tests

- New \`tests/package-exports.test.ts\` with **19 regression guards**: every plugin entry has ESM + CJS + types, every optional bundler peerDep is marked optional, \`./package.json\` is exported, \`engines\` contains only \`node\`.
- Full suite: 12 files, **383 tests** passing.
- Sandbox install verified under \`npm install\`, \`yarn add\` (yarn-berry with \`nodeLinker: node-modules\`), and \`pnpm add\`.

## Net consumer impact

After this ships in v2.0.1:
- ✅ \`yarn add tailwindcss-obfuscator\` no longer prints EBADENGINE warning
- ✅ \`npm install tailwindcss-obfuscator\` same
- ✅ Vite / Webpack / esbuild bundle analyzers no longer crash on the package
- ✅ Next.js / Nuxt framework probes no longer crash
- ✅ \`tw-obfuscator --version\` correctly reports the installed version

## Maintainer rule added (CLAUDE.md / AGENTS.md / GEMINI.md)

New section \"Documentation must always travel with the change\" with an explicit checklist of files to sweep on every modification (root README, package README, every \`docs/**\` page, \`llms.txt\`, CONTRIBUTING.md, PR template, changeset, \`jose/scripts/github/*\`, the AI trio).