### PR TITLE
docs(seo): homepage SEO + GEO overhaul (JSON-LD, keyword-dense hero, 3-CTA, on-page FAQ)

### DIFF
--- a/.changeset/docs-homepage-seo-and-geo-overhaul.md
+++ b/.changeset/docs-homepage-seo-and-geo-overhaul.md
@@ -1,0 +1,21 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Docs homepage SEO + GEO overhaul (no package code change).
+
+The live homepage at https://josedacosta.github.io/tailwindcss-obfuscator/ now ships :
+
+**Three JSON-LD structured-data blocks** in the page head, picked up by Google Knowledge Panels, Google AI Overviews, Perplexity, ChatGPT search, Claude search, and Bing :
+
+- `SoftwareApplication` — name, alternateName, applicationCategory, operatingSystem, version, license, $0 offer, author, code repository, programming language. Drives Knowledge Panel cards.
+- `FAQPage` with 7 questions — written verbatim in user voice (real Google search intents), each Q&A 2-4 sentences, optimised so an LLM can quote them back.
+- `BreadcrumbList` — Home → Get Started.
+
+**Stronger hero copy** — more keyword-dense, names every supported bundler and meta-framework on the first paint, leads with the value prop ("30–60 % bundle reduction") instead of a vague tagline.
+
+**Three-CTA hierarchy** — Get Started (brand), Compare with mangle (alt, points to /research/comparison), View on GitHub (alt). Replaces the previous two-CTA layout that under-promoted the comparison page.
+
+**On-page FAQ section** at the bottom of the homepage that mirrors the FAQPage JSON-LD — same 7 questions, same answers, fully crawlable Markdown so the schema has on-page text backing it (Google requires the schema content to also appear visibly on the page).
+
+Verified via local `pnpm docs:build` — all three `<script type="application/ld+json">` blocks are emitted into the rendered `dist/index.html`. After this lands and Pages redeploys, validate via Google's [Rich Results Test](https://search.google.com/test/rich-results) and Schema.org's [Schema Markup Validator](https://validator.schema.org/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,19 +36,146 @@ head:
   - - link
     - rel: canonical
       href: https://josedacosta.github.io/tailwindcss-obfuscator/
+  # ─── JSON-LD: SoftwareApplication ───
+  # Tells Google + LLMs what this software is, who made it, what it costs,
+  # and what platforms it runs on. Drives Knowledge Panel cards on Google.
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "tailwindcss-obfuscator",
+        "alternateName": ["Tailwind CSS Obfuscator", "Tailwind Class Mangler"],
+        "applicationCategory": "DeveloperApplication",
+        "applicationSubCategory": "Build tool / CSS optimizer",
+        "operatingSystem": "Cross-platform (Node.js >= 18)",
+        "url": "https://josedacosta.github.io/tailwindcss-obfuscator/",
+        "downloadUrl": "https://www.npmjs.com/package/tailwindcss-obfuscator",
+        "softwareVersion": "2.0.0",
+        "license": "https://opensource.org/licenses/MIT",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "description": "Build-time Tailwind CSS class obfuscator and mangler. Rewrites verbose Tailwind utility classes into short opaque identifiers in the shipped HTML, CSS, and JS bundle. Cuts CSS bundle size by 30-60% and protects design systems from copy-paste reverse-engineering. Supports Vite, Webpack, Rollup, esbuild, Rspack, Farm, Next.js, Nuxt, SvelteKit, Astro, Solid.js, Qwik, React Router 7 and TanStack Router, on Tailwind CSS v3 and v4.",
+        "keywords": "tailwindcss obfuscator, tailwind mangle, css class obfuscation, tailwindcss-mangle alternative, tailwind v4, tailwind v3, vite plugin, webpack plugin, design system protection",
+        "author": {
+          "@type": "Person",
+          "name": "José DA COSTA",
+          "url": "https://www.josedacosta.info"
+        },
+        "codeRepository": "https://github.com/josedacosta/tailwindcss-obfuscator",
+        "programmingLanguage": "TypeScript"
+      }
+  # ─── JSON-LD: FAQPage ───
+  # Quoted verbatim by Google AI Overview, Perplexity, ChatGPT search, Claude
+  # search. Each Q/A is intentionally written in the user's voice (real Google
+  # query intents) so an LLM can reproduce the answer.
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How do I prevent people from copying my Tailwind CSS design system?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Install tailwindcss-obfuscator at build time. It rewrites every Tailwind utility class (bg-blue-500, flex, items-center) into short opaque identifiers (tw-a, tw-b, tw-c) inside the shipped HTML, CSS, and JS bundle. Anyone view-source-ing your site sees <div class=\"tw-f tw-g tw-h\"> instead of your readable design tokens. Combined with HTML minification and source-map omission, copying your design system goes from minutes to hours."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I obfuscate Tailwind CSS classes in production?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Install tailwindcss-obfuscator and add its plugin to your build tool. For Vite: import tailwindCssObfuscator from 'tailwindcss-obfuscator/vite' and add it to the plugins array in vite.config.ts. The obfuscator only runs on production builds (vite build / next build) and is silent in dev mode. Identical entry points exist for Webpack, Rollup, esbuild, Rspack, Farm, and Nuxt."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I shrink my Tailwind CSS bundle size?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Tailwind's built-in JIT removes unused utilities; that is the baseline. On top of that, tailwindcss-obfuscator rewrites the remaining classes from long readable names like bg-blue-500 hover:bg-blue-600 dark:bg-blue-700 into short identifiers tw-a tw-b tw-c, shaving an additional 30-60 percent off the gzipped CSS bundle on CSS-heavy pages. The bigger your CSS budget, the more you save."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Tailwind CSS itself have a built-in way to obfuscate classes?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Tailwind Labs has explicitly chosen not to ship a class-mangling pass upstream. The two active third-party tools are tailwindcss-obfuscator (AST-based, every modern bundler, built around obfuscation) and tailwindcss-mangle (mangling for tree-shaking, Vite and Webpack only)."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Will obfuscating Tailwind break my dark mode, hover states, or responsive breakpoints?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. The obfuscator rewrites class names consistently across CSS selectors AND every class= / className= reference in your bundle. Variants like dark:bg-gray-900, hover:bg-blue-600, md:flex, 2xl:grid-cols-4 keep working because the variant and the base class are renamed together as a single unit."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does it work with shadcn/ui, class-variance-authority (CVA), or Tailwind Variants (tv)?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. The AST-based extractor recognises cn(), clsx(), classnames(), twMerge(), cva(), and tv() natively, including string literals nested inside variants, compoundVariants, defaultVariants, and slot definitions."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does tailwindcss-obfuscator work with Next.js Turbopack?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes, since v2.0.1. Turbopack does not expose a plugin API, so the supported pattern is the post-build CLI: next build && tw-obfuscator run --build-dir .next. The output is identical to the Webpack-plugin path. Alternatively, opt out of Turbopack with next build --webpack and the Webpack plugin attaches at build time."
+            }
+          }
+        ]
+      }
+  # ─── JSON-LD: BreadcrumbList ───
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+          {
+            "@type": "ListItem",
+            "position": 1,
+            "name": "Home",
+            "item": "https://josedacosta.github.io/tailwindcss-obfuscator/"
+          },
+          {
+            "@type": "ListItem",
+            "position": 2,
+            "name": "Get Started",
+            "item": "https://josedacosta.github.io/tailwindcss-obfuscator/guide/getting-started"
+          }
+        ]
+      }
 
 hero:
   name: tailwindcss-obfuscator
-  text: Protect Your CSS Intellectual Property
-  tagline: A powerful Tailwind CSS class obfuscation tool that transforms readable classes into cryptic identifiers while maintaining full functionality.
+  text: Mangle Tailwind classes. Shrink your CSS by 30–60%.
+  tagline: Build-time Tailwind CSS class obfuscator (mangler). Rewrites bg-blue-500 → tw-a in the shipped bundle. Protects your design system from copy-paste reverse-engineering. Vite · Webpack · Rollup · esbuild · Rspack · Farm · Next.js · Nuxt · SvelteKit · Astro · Solid · Qwik. Tailwind v3 & v4.
   image:
     light: /images/tailwindcss-obfuscator/logo-horizontal.svg
     dark: /images/tailwindcss-obfuscator/logo-horizontal-white.svg
     alt: tailwindcss-obfuscator
   actions:
     - theme: brand
-      text: Get Started
+      text: Get Started in 30 sec
       link: /guide/getting-started
+    - theme: alt
+      text: Compare with mangle
+      link: /research/comparison
     - theme: alt
       text: View on GitHub
       link: https://github.com/josedacosta/tailwindcss-obfuscator
@@ -467,3 +594,59 @@ export default defineConfig({
 | Rollup  | `tailwindcss-obfuscator/rollup`  | ✅ Stable |
 | Rspack  | `tailwindcss-obfuscator/rspack`  | ✅ Stable |
 | Farm    | `tailwindcss-obfuscator/farm`    | ✅ Stable |
+
+## Frequently asked questions
+
+> Real questions developers ask Google + AI assistants when they're hunting for a tool like this. Each answer is intentionally written so an LLM can quote it back verbatim. The same Q&A is published as `FAQPage` JSON-LD in the page head for Google AI Overviews.
+
+### How do I prevent people from copying my Tailwind CSS design system?
+
+Install **`tailwindcss-obfuscator`** at build time. It rewrites every Tailwind utility class (`bg-blue-500`, `flex`, `items-center`) into short opaque identifiers (`tw-a`, `tw-b`, `tw-c`) inside the shipped HTML, CSS, and JS bundle. Anyone view-source-ing your site sees `<div class="tw-f tw-g tw-h">` instead of your readable design tokens. Combined with HTML minification and source-map omission, copying your design system goes from minutes to hours.
+
+### How do I obfuscate Tailwind CSS classes in production?
+
+Install `tailwindcss-obfuscator` and add its plugin to your build tool. For Vite :
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
+import tailwindCssObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [tailwindcss(), tailwindCssObfuscator({ prefix: "tw-" })],
+});
+```
+
+The obfuscator only runs on production builds (`vite build` / `next build`) and stays silent in dev mode. Identical entry points exist for **Webpack, Rollup, esbuild, Rspack, Farm, Nuxt**, plus a standalone **`tw-obfuscator` CLI** for any other build chain.
+
+### How do I shrink my Tailwind CSS bundle size?
+
+Tailwind's built-in JIT removes unused utilities — that's the baseline. On top of that, **`tailwindcss-obfuscator`** rewrites the remaining classes from long readable names (`bg-blue-500 hover:bg-blue-600 dark:bg-blue-700`) into short identifiers (`tw-a tw-b tw-c`), shaving an additional **30–60 %** off the gzipped CSS bundle on CSS-heavy pages. The bigger your CSS budget, the more you save.
+
+### Does Tailwind CSS itself have a built-in way to obfuscate classes?
+
+No. Tailwind Labs has explicitly chosen not to ship a class-mangling pass upstream. The two active third-party tools are `tailwindcss-obfuscator` (this project — AST-based, every modern bundler, built around obfuscation) and `tailwindcss-mangle` (mangling for tree-shaking, Vite + Webpack only). See the [full comparison](/research/comparison) for the trade-offs.
+
+### Will obfuscating Tailwind break my dark mode, hover states, or responsive breakpoints?
+
+No. The obfuscator rewrites class names consistently across CSS selectors AND every `class=` / `className=` reference in your bundle. Variants like `dark:bg-gray-900`, `hover:bg-blue-600`, `md:flex`, `2xl:grid-cols-4` keep working because the variant and the base class are renamed together as a single unit.
+
+### Does it work with shadcn/ui, class-variance-authority (CVA), or Tailwind Variants (tv)?
+
+Yes — out of the box. The AST-based extractor recognises `cn()`, `clsx()`, `classnames()`, `twMerge()`, `cva()` and `tv()` natively, including string literals nested inside `variants`, `compoundVariants`, `defaultVariants`, and slot definitions.
+
+### Does tailwindcss-obfuscator work with Next.js Turbopack?
+
+**Yes, since v2.0.1.** Turbopack does not expose a plugin API, so the supported pattern is the **post-build CLI** :
+
+```jsonc
+// package.json
+{
+  "scripts": {
+    "build": "next build && tw-obfuscator run --build-dir .next --content 'app/**/*.{js,jsx,ts,tsx,mdx}' --content 'components/**/*.{js,jsx,ts,tsx,mdx}' --css 'app/**/*.css'",
+  },
+}
+```
+
+The output is identical to the Webpack-plugin path. Alternatively, opt out of Turbopack with `next build --webpack` and the Webpack plugin attaches at build time. Full details in the [Next.js guide](/guide/nextjs#turbopack).


### PR DESCRIPTION
## Summary

Closes the SEO gaps audit identified on the live homepage at https://josedacosta.github.io/tailwindcss-obfuscator/. **No package code change** — all docs-only.

## What lands

### Three JSON-LD structured-data blocks in the page head

Picked up by Google Knowledge Panels, Google AI Overview, Perplexity, ChatGPT search, Claude search, Bing :

- **\`SoftwareApplication\`** — name, alternateName, category, OS, version, license, \`$0\` offer, author, code repository, programming language. Drives Knowledge Panel cards.
- **\`FAQPage\`** with 7 questions — written verbatim in user voice (real Google query intents), each Q/A 2-4 sentences. Quoted back by AI search assistants.
- **\`BreadcrumbList\`** — Home → Get Started.

### Stronger hero copy

Keyword-dense first paint, names every supported bundler and meta-framework, leads with the value prop (\"30-60% bundle reduction\") instead of a vague tagline.

### Three-CTA hierarchy

Get Started (brand) | Compare with mangle (alt → \`/research/comparison\`) | View on GitHub (alt). Replaces the 2-CTA layout that under-promoted the comparison page.

### On-page FAQ section at the bottom

Mirrors the FAQPage JSON-LD — same 7 questions, same answers, fully crawlable Markdown. Required by Google: the schema content must also appear visibly on the page.

## Verification

- Local \`pnpm docs:build\` — green.
- Built \`dist/index.html\` contains all 3 \`<script type=\"application/ld+json\">\` blocks with expected \`@type\` values: \`SoftwareApplication\`, \`FAQPage\`, \`BreadcrumbList\`, plus nested \`Offer\`, \`Person\`, \`Question\`, \`Answer\`, \`ListItem\`.

## Test plan after merge

- [ ] Pages workflow deploys cleanly
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results?url=https%3A%2F%2Fjosedacosta.github.io%2Ftailwindcss-obfuscator%2F) returns ✅ for FAQPage + SoftwareApplication
- [ ] [Schema.org Validator](https://validator.schema.org/#url=https%3A%2F%2Fjosedacosta.github.io%2Ftailwindcss-obfuscator%2F) returns 0 errors
- [ ] Homepage renders the new 3-CTA hero + FAQ section visibly