### PR TITLE
docs(comparison): surface v2.0.1 advances in both comparison tables (README + /research/comparison)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,24 +234,29 @@ There are a handful of class-mangling tools out there. Here's how this one stack
 
 <div align="center">
 
-| Capability                                                          | 🛡️&nbsp;**tailwindcss-obfuscator** | 🔧&nbsp;tailwindcss-mangle |   🌐&nbsp;Obfustail   | ⚙️&nbsp;PostCSS minifiers | 🅒&nbsp;Tailwind CSS itself |
-| ------------------------------------------------------------------- | :--------------------------------: | :------------------------: | :-------------------: | :-----------------------: | :------------------------: |
-| Tailwind v4 (CSS-first) support                                     |             ✅ Native              |    ✅ via CSS scan (v9)    |      ✅ v4 only       |            n/a            |             ✅             |
-| Tailwind v3 (config-file) support                                   |                 ✅                 |             ✅             |          ❌           |            n/a            |             ✅             |
-| Renames classes (HTML / JS / CSS)                                   |                 ✅                 |             ✅             |          ✅           |            ❌             |             ❌             |
-| Doesn't modify your source files                                    |                 ✅                 |             ✅             | ❌ rewrites in place  |            ✅             |             ✅             |
-| Per-utility obfuscation (vs. per-string)                            |                 ✅                 |             ✅             |  ❌ per-full-string   |            n/a            |            n/a             |
-| Unified `unplugin` core (Vite/Webpack/Rollup/esbuild/Rspack/Farm)   |             ✅ All six             |   ⚠️ Vite + Webpack only   | ❌ build-time script  |            ❌             |             ❌             |
-| AST-based JSX/TSX transformer                                       |              ✅ Babel              |          ⚠️ Regex          |       ❌ Regex        |            n/a            |            n/a             |
-| Vue SFC + Svelte `class:` directive                                 |                 ✅                 |         ⚠️ Partial         |          ❌           |            n/a            |            n/a             |
-| `cn()` / `clsx()` / `classnames()` / `twMerge()` / `cva()` / `tv()` |             ✅ All six             |           ⚠️ Two           | ❌ Manual `safelist`  |            ❌             |             ❌             |
-| Type-safe options + typed errors                                    |            ✅ Strict TS            |          ⚠️ Loose          |      ❌ Pure JS       |            n/a            |            n/a             |
-| Source maps for transformed files                                   |                 ✅                 |             ⚠️             |          ❌           |            ✅             |             ✅             |
-| Reversible mapping file emitted                                     |                 ✅                 |             ✅             |          ✅           |            ❌             |             ❌             |
-| Standalone CLI (any project)                                        |         ✅ `tw-obfuscator`         |       ✅ `tw-patch`        | ❌ inline node script |            ✅             |             ✅             |
-| Per-build randomization (no global state)                           |                 ✅                 |             ❌             |          ✅           |            n/a            |            n/a             |
-| Tailwind config validator                                           |                 ✅                 |             ❌             |          ❌           |            ❌             |             ❌             |
-| Active framework coverage                                           |            **20+ apps**            |             ~5             |      1 (Next.js)      |            n/a            |            n/a             |
+| Capability                                                            | 🛡️&nbsp;**tailwindcss-obfuscator** | 🔧&nbsp;tailwindcss-mangle |        🌐&nbsp;Obfustail        | ⚙️&nbsp;PostCSS minifiers | 🅒&nbsp;Tailwind CSS itself |
+| --------------------------------------------------------------------- | :--------------------------------: | :------------------------: | :-----------------------------: | :-----------------------: | :------------------------: |
+| Tailwind v4 (CSS-first) support                                       |             ✅ Native              |    ✅ via CSS scan (v9)    |           ✅ v4 only            |            n/a            |             ✅             |
+| Tailwind v3 (config-file) support                                     |                 ✅                 |             ✅             |               ❌                |            n/a            |             ✅             |
+| Renames classes (HTML / JS / CSS)                                     |                 ✅                 |             ✅             |               ✅                |            ❌             |             ❌             |
+| Doesn't modify your source files                                      |                 ✅                 |             ✅             |      ❌ rewrites in place       |            ✅             |             ✅             |
+| Per-utility obfuscation (vs. per-string)                              |                 ✅                 |             ✅             |       ❌ per-full-string        |            n/a            |            n/a             |
+| Unified `unplugin` core (Vite/Webpack/Rollup/esbuild/Rspack/Farm)     |             ✅ All six             |   ⚠️ Vite + Webpack only   |      ❌ build-time script       |            ❌             |             ❌             |
+| AST-based JSX/TSX transformer                                         |              ✅ Babel              |          ⚠️ Regex          |            ❌ Regex             |            n/a            |            n/a             |
+| Vue SFC + Svelte `class:` directive                                   |                 ✅                 |         ⚠️ Partial         |               ❌                |            n/a            |            n/a             |
+| `cn()` / `clsx()` / `classnames()` / `twMerge()` / `cva()` / `tv()`   |             ✅ All six             |           ⚠️ Two           |      ❌ Manual `safelist`       |            ❌             |             ❌             |
+| Type-safe options + typed errors                                      |            ✅ Strict TS            |          ⚠️ Loose          |           ❌ Pure JS            |            n/a            |            n/a             |
+| Source maps for transformed files                                     |                 ✅                 |             ⚠️             |               ❌                |            ✅             |             ✅             |
+| Reversible mapping file emitted                                       |                 ✅                 |             ✅             |               ✅                |            ❌             |             ❌             |
+| Standalone CLI (any project)                                          |         ✅ `tw-obfuscator`         |       ✅ `tw-patch`        |      ❌ inline node script      |            ✅             |             ✅             |
+| Per-build randomization (no global state)                             |                 ✅                 |             ❌             |               ✅                |            n/a            |            n/a             |
+| Tailwind config validator                                             |                 ✅                 |             ❌             |               ❌                |            ❌             |             ❌             |
+| Active framework coverage                                             |            **20+ apps**            |             ~5             |           1 (Next.js)           |            n/a            |            n/a             |
+| **Unquoted HTML attributes** (`class=foo`, HTML5 spec)                |          ✅ since v2.0.1           |             ❌             |               ❌                |            n/a            |            n/a             |
+| **Next.js Turbopack** (post-build CLI workaround documented + tested) |          ✅ since v2.0.1           |             ❌             | ⚠️ accidental (Next.js + Turbo) |            n/a            |            n/a             |
+| **npm publish with provenance** (Sigstore / OIDC attestation)         |                 ✅                 |             ❌             |               ❌                |          varies           |            n/a             |
+| **OpenSSF Scorecard published**                                       |             ✅ weekly              |             ❌             |               ❌                |            n/a            |            n/a             |
+| **SBOM (SPDX-JSON) attached to every GitHub release**                 |                 ✅                 |             ❌             |               ❌                |            n/a            |            n/a             |
 
 </div>
 

--- a/docs/research/comparison.md
+++ b/docs/research/comparison.md
@@ -24,25 +24,30 @@ PostCSS minifiers and Tailwind itself are routinely confused with class manglers
 
 ## Quick-glance matrix
 
-| Capability                                                 | 🛡️ tailwindcss-obfuscator |  🔧 tailwindcss-mangle   |        🌐 Obfustail        | ⚙️ PostCSS minifiers | 🅒 Tailwind CSS |
-| ---------------------------------------------------------- | :-----------------------: | :----------------------: | :------------------------: | :------------------: | :------------: |
-| Renames classes in HTML / JS / CSS                         |            ✅             |            ✅            |             ✅             |          ❌          |       ❌       |
-| Tailwind v3 support                                        |            ✅             |            ✅            |             ❌             |         n/a          |      n/a       |
-| Tailwind v4 support                                        |         ✅ Native         | ✅ via CSS scan (v9.0.0) |             ✅             |         n/a          |      n/a       |
-| Doesn't modify your source files                           |            ✅             |            ✅            |    ❌ rewrites in place    |          ✅          |       ✅       |
-| Per-utility obfuscation (smaller output)                   |            ✅             |            ✅            | ❌ per-string (less reuse) |          ❌          |       ❌       |
-| AST-based JSX/TSX extraction                               |         ✅ Babel          |         ⚠️ Regex         |          ❌ Regex          |         n/a          |      n/a       |
-| Vue SFC + Svelte `class:` directive                        |            ✅             |        ⚠️ Partial        |             ❌             |         n/a          |      n/a       |
-| `cn()` / `clsx()` / `cva()` / `tv()` extraction            |        ✅ All six         |          ⚠️ Two          |         ❌ Manual          |          ❌          |       ❌       |
-| Unified `unplugin` core (Vite/Webpack/Rollup/...)          |            ✅             |      ⚠️ Per-bundler      |      ❌ Build script       |          ❌          |       ❌       |
-| Bundlers shipped (Vite/Webpack/Rollup/esbuild/Rspack/Farm) |           6 / 6           |          2 / 6           |           0 / 6            |         n/a          |      n/a       |
-| Standalone CLI                                             |    ✅ `tw-obfuscator`     |      ✅ `tw-patch`       |   ❌ inline node script    |          ✅          |       ✅       |
-| Source maps for transformed files                          |            ✅             |            ⚠️            |             ❌             |          ✅          |       ✅       |
-| Reversible mapping file emitted                            |            ✅             |            ✅            |             ✅             |          ❌          |       ❌       |
-| Per-build randomisation (no global state)                  |            ✅             |            ❌            |             ✅             |         n/a          |      n/a       |
-| Type-safe config (strict TypeScript)                       |            ✅             |         ⚠️ Loose         |         ❌ Pure JS         |         n/a          |      n/a       |
-| Active framework coverage (sample apps)                    |       **20+ apps**        |            ~5            |        1 (Next.js)         |         n/a          |      n/a       |
-| Licence                                                    |            MIT            |           MIT            |            MIT             |         MIT          |      MIT       |
+| Capability                                                 | 🛡️ tailwindcss-obfuscator |  🔧 tailwindcss-mangle   |         🌐 Obfustail         | ⚙️ PostCSS minifiers | 🅒 Tailwind CSS |
+| ---------------------------------------------------------- | :-----------------------: | :----------------------: | :--------------------------: | :------------------: | :------------: |
+| Renames classes in HTML / JS / CSS                         |            ✅             |            ✅            |              ✅              |          ❌          |       ❌       |
+| Tailwind v3 support                                        |            ✅             |            ✅            |              ❌              |         n/a          |      n/a       |
+| Tailwind v4 support                                        |         ✅ Native         | ✅ via CSS scan (v9.0.0) |              ✅              |         n/a          |      n/a       |
+| Doesn't modify your source files                           |            ✅             |            ✅            |     ❌ rewrites in place     |          ✅          |       ✅       |
+| Per-utility obfuscation (smaller output)                   |            ✅             |            ✅            |  ❌ per-string (less reuse)  |          ❌          |       ❌       |
+| AST-based JSX/TSX extraction                               |         ✅ Babel          |         ⚠️ Regex         |           ❌ Regex           |         n/a          |      n/a       |
+| Vue SFC + Svelte `class:` directive                        |            ✅             |        ⚠️ Partial        |              ❌              |         n/a          |      n/a       |
+| `cn()` / `clsx()` / `cva()` / `tv()` extraction            |        ✅ All six         |          ⚠️ Two          |          ❌ Manual           |          ❌          |       ❌       |
+| Unified `unplugin` core (Vite/Webpack/Rollup/...)          |            ✅             |      ⚠️ Per-bundler      |       ❌ Build script        |          ❌          |       ❌       |
+| Bundlers shipped (Vite/Webpack/Rollup/esbuild/Rspack/Farm) |           6 / 6           |          2 / 6           |            0 / 6             |         n/a          |      n/a       |
+| Standalone CLI                                             |    ✅ `tw-obfuscator`     |      ✅ `tw-patch`       |    ❌ inline node script     |          ✅          |       ✅       |
+| Source maps for transformed files                          |            ✅             |            ⚠️            |              ❌              |          ✅          |       ✅       |
+| Reversible mapping file emitted                            |            ✅             |            ✅            |              ✅              |          ❌          |       ❌       |
+| Per-build randomisation (no global state)                  |            ✅             |            ❌            |              ✅              |         n/a          |      n/a       |
+| Type-safe config (strict TypeScript)                       |            ✅             |         ⚠️ Loose         |          ❌ Pure JS          |         n/a          |      n/a       |
+| Active framework coverage (sample apps)                    |       **20+ apps**        |            ~5            |         1 (Next.js)          |         n/a          |      n/a       |
+| **Unquoted HTML attributes** (HTML5 `class=foo`)           |      ✅ since v2.0.1      |            ❌            |              ❌              |         n/a          |      n/a       |
+| **Next.js Turbopack** (post-build CLI, tested)             |      ✅ since v2.0.1      |            ❌            | ⚠️ accidental (Next + Turbo) |         n/a          |      n/a       |
+| **npm publish with provenance** (Sigstore / OIDC)          |            ✅             |            ❌            |              ❌              |        varies        |      n/a       |
+| **OpenSSF Scorecard** published weekly                     |            ✅             |            ❌            |              ❌              |         n/a          |      n/a       |
+| **SBOM (SPDX-JSON)** attached to every GitHub release      |            ✅             |            ❌            |              ❌              |         n/a          |      n/a       |
+| Licence                                                    |            MIT            |           MIT            |             MIT              |         MIT          |      MIT       |
 
 ## Per-tool deep-dive
 


### PR DESCRIPTION
The two comparison matrices were missing every user-facing capability shipped this round. Five new rows added to **both** tables (README + docs/research/comparison.md), identical wording:

| New row | Where only we offer it |
|---|---|
| **Unquoted HTML attributes** (HTML5 `class=foo`) | extractor + transformer support shipped in #19 |
| **Next.js Turbopack** (post-build CLI, tested) | shipped in #20 — only us officially |
| **npm publish with provenance** (Sigstore / OIDC) | configured via release.yml (`NPM_CONFIG_PROVENANCE: true`) + workflow OIDC permissions |
| **OpenSSF Scorecard** published weekly | shipped in #15 — workflow + badge in README |
| **SBOM (SPDX-JSON)** on every release | shipped in #15 — `anchore/sbom-action` attaches it |

Verified `pnpm docs:build` passes; both tables render. Comparison page is the canonical source; the README table is intentionally a shortened mirror.