### PR TITLE
ci(release): add workflow_dispatch trigger so release.yml can be manually re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    # Manual trigger from the Actions UI or via `gh workflow run release.yml`.
+    # Useful when a `push:`-triggered run got stuck in pending state without
+    # ever allocating jobs (rare GitHub Actions infra glitch) and force-cancel
+    # is needed before the next release attempt.
 
 concurrency:
   group: release-${{ github.ref }}


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger to release.yml. Useful when a push-triggered run gets stuck pending without job allocation (rare GitHub Actions infra glitch) — manual re-run via `gh workflow run release.yml` or the UI button starts a fresh run cleanly. No change to release logic.