### PR TITLE
fix(test): turbopack-postbuild test fails on Windows runners — fast-glob needs forward-slash globs

### DIFF
--- a/packages/tailwindcss-obfuscator/tests/turbopack-postbuild.test.ts
+++ b/packages/tailwindcss-obfuscator/tests/turbopack-postbuild.test.ts
@@ -21,6 +21,13 @@ import { transformDirectory } from "../src/transformers/index.js";
 import { createContext, initializeContext } from "../src/core/context.js";
 import { createLogger } from "../src/utils/logger.js";
 
+/**
+ * fast-glob requires forward-slash glob patterns even on Windows, but
+ * `path.join()` returns backslashes on Windows, which silently match
+ * nothing. Normalise glob patterns to POSIX separators.
+ */
+const toPosix = (p: string): string => p.replace(/\\/g, "/");
+
 describe("Turbopack post-build CLI pipeline", () => {
   let projectDir: string;
   let nextDir: string;
@@ -75,7 +82,7 @@ describe("Turbopack post-build CLI pipeline", () => {
       {
         prefix: "tw-",
         randomize: false,
-        content: [join(appDir, "**/*.{ts,tsx,js,jsx}")],
+        content: [toPosix(join(appDir, "**/*.{ts,tsx,js,jsx}"))],
         outputDir: join(projectDir, ".tw-obfuscation"),
       },
       "production"
@@ -115,7 +122,7 @@ describe("Turbopack post-build CLI pipeline", () => {
       {
         prefix: "tw-",
         randomize: false,
-        content: [join(appDir, "**/*.{ts,tsx,js,jsx}")],
+        content: [toPosix(join(appDir, "**/*.{ts,tsx,js,jsx}"))],
         outputDir: join(projectDir, ".tw-obfuscation"),
       },
       "production"


### PR DESCRIPTION
Caught by CI run #25090627776 (commit e4644ad) — Test (Node 20/22) on Windows-latest failed with `expected 0 to be greater than 0` while macOS / Linux passed.

**Root cause**: `path.join(appDir, "**/*.{ts,tsx,js,jsx}")` returns backslash-separated patterns on Windows, which fast-glob silently treats as no-match (backslashes are escape characters in glob syntax, not directory separators).

**Fix**: `toPosix(p)` helper that normalises to forward slashes before passing to `createContext({ content: [...] })`. Test passes 2/2 locally; full suite back to 395/395.