### PR TITLE
docs(readme): add visual breathing room above and below the logo on both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<br /><br />
+
 <a href="https://github.com/josedacosta/tailwindcss-obfuscator">
   <img src="./docs/public/images/tailwindcss-obfuscator/logo-horizontal.svg" alt="Tailwind CSS Obfuscator" width="960">
 </a>

--- a/packages/tailwindcss-obfuscator/README.md
+++ b/packages/tailwindcss-obfuscator/README.md
@@ -1,8 +1,12 @@
+<br /><br />
+
 <p align="center">
   <a href="https://josedacosta.github.io/tailwindcss-obfuscator/">
     <img src="https://raw.githubusercontent.com/josedacosta/tailwindcss-obfuscator/main/docs/public/images/tailwindcss-obfuscator/logo-horizontal.svg" alt="tailwindcss-obfuscator" width="500">
   </a>
 </p>
+
+<br />
 
 <h1 align="center">tailwindcss-obfuscator</h1>
 


### PR DESCRIPTION
Aesthetic tweak — the logo at the top of the root README and the package README felt cramped. Adds `<br />` tags before and after the `<img>` block on each. No content change.