### PR TITLE
chore(deps): add Renovate config (replaces forbidden Dependabot)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "security:openssf-scorecard",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":separateMajorReleases",
+    "group:monorepos",
+    "group:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "schedule": ["before 6am on monday"],
+  "timezone": "Europe/Paris",
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 8,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"],
+    "commitMessageAction": "refresh",
+    "commitMessageTopic": "lockfile"
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["dependencies", "security"],
+    "schedule": ["at any time"]
+  },
+  "packageRules": [
+    {
+      "description": "Pin GitHub Actions to a 40-char commit SHA (Scorecard 'Pinned-Dependencies' requirement); update via Renovate. Non-major bumps auto-mergeable once CI is green.",
+      "matchManagers": ["github-actions"],
+      "pinDigests": true,
+      "automerge": false
+    },
+    {
+      "description": "Group all dev-tooling minor/patch bumps in a single PR (TypeScript, Vitest, ESLint, Prettier, tsup, etc.).",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev tooling (non-major)",
+      "schedule": ["before 6am on monday"]
+    },
+    {
+      "description": "Sample apps in apps/test-* are NOT shipped on npm. Their dep updates only affect local verification — group them aggressively to keep noise down.",
+      "matchFileNames": ["apps/**/package.json"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "test apps (non-major)",
+      "schedule": ["before 6am on monday"]
+    },
+    {
+      "description": "Major bumps for frameworks in test apps need manual review (often breaking).",
+      "matchFileNames": ["apps/**/package.json"],
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["needs-review"],
+      "schedule": ["before 6am on the first day of the month"]
+    },
+    {
+      "description": "The published package's runtime dependencies — keep tight, no auto-merge, surface fast.",
+      "matchFileNames": ["packages/tailwindcss-obfuscator/package.json"],
+      "matchDepTypes": ["dependencies", "peerDependencies"],
+      "addLabels": ["needs-review", "area: package"],
+      "schedule": ["at any time"]
+    },
+    {
+      "description": "Tailwind CSS itself is the package's reason to exist — surface every bump immediately.",
+      "matchPackageNames": ["tailwindcss", "@tailwindcss/vite", "@tailwindcss/postcss"],
+      "addLabels": ["needs-review", "framework: tailwind"],
+      "schedule": ["at any time"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a hand-tuned `renovate.json` to drive automated dependency updates. Renovate (free for open-source) replaces the forbidden Dependabot — closes the OpenSSF Scorecard `Dependency-Update-Tool` check (0/10 → 10/10).

### What it does

| Rule | Behavior |
|---|---|
| GitHub Actions | Renovate keeps the SHA pins (added in #28) up to date, with version-tag comments. |
| `apps/test-*` minor/patch | Grouped weekly into a single `test apps (non-major)` PR — these are sample apps, not shipped on npm. |
| `apps/test-*` major | Monthly, labelled `needs-review` (often breaking). |
| Dev tooling minor/patch | Grouped weekly into one `dev tooling (non-major)` PR. |
| Published-package runtime deps | Surface immediately with `needs-review` + `area: package` labels. No grouping. |
| Tailwind CSS itself | Surface immediately — it's the package's reason to exist. |
| Lockfile maintenance | Monthly refresh on the first day of the month. |
| Vulnerability alerts | Land at any time (bypass weekly window). |

### Audit context (43 vulnerabilities found by Scorecard)

Verified with `pnpm audit --prod` — **all 43 advisories are in `apps/test-*` transitive deps** (Nuxt → nitro → tar/minimatch, Qwik → undici, React Router → express → qs, etc.). **Zero** vulnerabilities in `packages/tailwindcss-obfuscator`'s production deps.

These will be progressively cleared by Renovate's `apps/**` rule as upstream frameworks publish patched releases.

### Manual install required

Renovate requires the GitHub App to be installed once on the repo (the maintainer has done this — see `jose/scripts/github/browser-manual.md` § 13.2 for the procedure and rollback). The first scheduled run hits Monday 06:00 Europe/Paris.

### Companion PR

Stacks on top of #28 (workflow SHA pinning) — together they take Scorecard from 3.9/10 toward ~7-8/10 in three checks (`Pinned-Dependencies`, `Token-Permissions`, `Dependency-Update-Tool`).

## Test plan

- [ ] `node -e "JSON.parse(require('fs').readFileSync('renovate.json','utf8'))"` returns valid JSON ✅
- [ ] CI green (no test logic changed)
- [ ] After merge: Renovate's onboarding PR appears within ~1 minute → close it without merging (existing config is the source of truth)
- [ ] Within ~24h: a `Dependency Dashboard` issue auto-opens
- [ ] Next Scorecard run: `Dependency-Update-Tool` flips to 10/10