### PR TITLE
docs(readme): add OpenSSF Best Practices passing badge to both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@
 
 <!-- Badges row 4 — security & supply chain -->
 <p>
+  <a href="https://www.bestpractices.dev/projects/12705">
+    <img alt="OpenSSF Best Practices" src="https://www.bestpractices.dev/projects/12705/badge">
+  </a>
   <a href="https://scorecard.dev/viewer/?uri=github.com/josedacosta/tailwindcss-obfuscator">
     <img alt="OpenSSF Scorecard" src="https://img.shields.io/ossf-scorecard/github.com/josedacosta/tailwindcss-obfuscator?style=for-the-badge&label=OpenSSF%20Scorecard&color=10b981&labelColor=000000">
   </a>

--- a/packages/tailwindcss-obfuscator/README.md
+++ b/packages/tailwindcss-obfuscator/README.md
@@ -22,6 +22,8 @@
   <a href="https://www.npmjs.com/package/tailwindcss-obfuscator"><img src="https://img.shields.io/npm/dm/tailwindcss-obfuscator.svg?style=flat-square" alt="npm downloads"></a>
   <a href="https://github.com/josedacosta/tailwindcss-obfuscator/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/tailwindcss-obfuscator.svg?style=flat-square" alt="license"></a>
   <a href="https://josedacosta.github.io/tailwindcss-obfuscator/"><img src="https://img.shields.io/badge/docs-online-brightgreen?style=flat-square" alt="docs"></a>
+  <a href="https://www.bestpractices.dev/projects/12705"><img src="https://www.bestpractices.dev/projects/12705/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/josedacosta/tailwindcss-obfuscator"><img src="https://img.shields.io/ossf-scorecard/github.com/josedacosta/tailwindcss-obfuscator?style=flat-square&label=OpenSSF%20Scorecard" alt="OpenSSF Scorecard"></a>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

Adds the **OpenSSF Best Practices passing badge** (project ID **12705**) alongside the existing OpenSSF Scorecard badge in both READMEs.

The project completed the OpenSSF Best Practices self-assessment today (2026-04-29) and earned the **passing** tier. Every criterion has a documented justification reviewable at <https://www.bestpractices.dev/projects/12705>.

### Badge URLs

- Image: <https://www.bestpractices.dev/projects/12705/badge>
- Public criteria + justifications page: <https://www.bestpractices.dev/projects/12705>

### Files touched

- \`README.md\` — added to "Badges row 4 — security & supply chain" before the Scorecard badge
- \`packages/tailwindcss-obfuscator/README.md\` — added to the npm-facing badges row

## Test plan

- [ ] Both badge images render on github.com (PR preview)
- [ ] After merge: the badges render on the live docs site / npm package page