### PR TITLE
ci: replace tag-object SHAs with real commit SHAs in workflow pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           fetch-depth: 0 # required by lastUpdated
 
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           git config --global user.name "José DA COSTA"
           git config --global user.email "contact@josedacosta.info"
 
-      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish
         id: changesets
-        uses: changesets/action@e87c8ed249971350e47fab7515075f44eb134e5b # v1.7.0
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm release
           version: pnpm changeset version

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
@@ -53,6 +53,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning dashboard
-        uses: github/codeql-action/upload-sarif@b2f9ef845756500b97acbdaf5c1dd4e9c1d15734 # v3.35.2
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

OpenSSF Scorecard runs were failing with \"imposter commit\" errors because four pinned actions had their **annotated tag-object SHAs** mistakenly used as the pin instead of the underlying **commit SHAs**. The Scorecard action's webapp validates that the pinned SHA is a real commit and silently rejects tag-object SHAs that masquerade as commits.

Audited every pinned action and fixed the four broken pins:

| Action | Was (tag-object SHA) | Now (commit SHA) |
|---|---|---|
| `pnpm/action-setup` | `a15d269...` | `fc06bc1...` |
| `changesets/action` | `e87c8ed...` | `6a0a831...` |
| `ossf/scorecard-action` | `ff5dd89...` | `62b2cac...` |
| `github/codeql-action/upload-sarif` | `b2f9ef8...` | `ce64ddc...` |

## Why this matters

Most actions tolerate tag-object SHAs because Git can dereference them when fetching, but they are technically incorrect (less reproducible — if the upstream tag is moved to another commit, the pin's intent becomes ambiguous) and the Scorecard action actively rejects them.

Effects of this fix:
- Scorecard runs will succeed and re-upload SARIF, clearing the **30 stale `PinnedDependenciesID` alerts** in the Security tab.
- The Scorecard score on scorecard.dev will refresh.
- All other workflows (CI, Release, Docs) continue to behave identically but are now strictly correct.

Per the new ULTRA-IMPORTANT security rule in `CLAUDE.md` (added this session), a workflow-verification failure is a supply-chain risk that must be fixed.

## Test plan

- [x] All 12 pinned actions audited via `gh api repos/<repo>/git/commits/<sha>` — every SHA now resolves to a commit
- [ ] CI green on this PR (uses the new `pnpm/action-setup` commit SHA)
- [ ] Once merged, watch the next scheduled / push-triggered Scorecard run on `main` succeed and refresh the SARIF alerts

## Type

- [x] CI / build infra
- [x] Security fix

## Changeset

Not applicable — workflow change, no published-package impact.