### PR TITLE
ci: rename release.yml to publish.yml to bypass workflow ID throttling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,22 @@
-name: Release
+name: Publish
+
+# Renamed from `release.yml` to `publish.yml` because GitHub kept the previous
+# workflow ID associated with the (now-removed) `environment: npm` declaration,
+# silently throttling every run to "pending" forever without ever allocating
+# a job. Renaming the file forces GitHub to mint a fresh workflow ID, breaking
+# the throttle. See git log for the chain of attempts.
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
-    # Manual trigger from the Actions UI or via `gh workflow run release.yml`.
+    # Manual trigger from the Actions UI or via `gh workflow run publish.yml`.
     # Useful when a `push:`-triggered run got stuck in pending state without
     # ever allocating jobs (rare GitHub Actions infra glitch) and force-cancel
     # is needed before the next release attempt.
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: publish-${{ github.ref }}
   cancel-in-progress: false
 
 # OpenSSF Scorecard "Token-Permissions": top-level empty; the release job

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -169,7 +169,7 @@ gh secret list -R josedacosta/tailwindcss-obfuscator | grep NPM_TOKEN
 Trigger the workflow manually with a no-op:
 
 ```bash
-gh workflow run release.yml -R josedacosta/tailwindcss-obfuscator
+gh workflow run publish.yml -R josedacosta/tailwindcss-obfuscator
 gh run watch -R josedacosta/tailwindcss-obfuscator
 ```
 


### PR DESCRIPTION
## Summary

Every push to \`main\` triggers \`.github/workflows/release.yml\`, but every run sits **\`pending\` forever with zero jobs allocated** and is later cancelled by the next push. Other workflows (CI, CodeQL, Docs, Scorecard) on the same commit run normally — only \`release.yml\` is stuck.

**Diagnosis** (from prior debugging session, confirmed today across 5+ stuck runs): GitHub keeps the workflow's internal ID associated with the (since-removed) \`environment: npm\` declaration. On personal accounts with no payment method on file, deployment-style runs are silently throttled. Removing the \`environment:\` line did *not* clear the association — it sticks to the workflow's internal ID, which is keyed by file path.

**Fix:** rename the file. GitHub mints a fresh workflow ID and the throttle breaks. Concurrency group also renamed (\`release-…\` → \`publish-…\`) to match.

## Side effect to watch after merge

\`jose/github.md\` documents that npm Trusted Publisher is configured against the previous filename \`release.yml\`. After this rename:
- The publish via \`NPM_TOKEN\` classic auth should still work (token is fallback).
- OIDC provenance will fail to bind until the maintainer re-binds on **npm.com → settings → packages → tailwindcss-obfuscator → Publishing access** (WebAuthn, browser flow).
- Since the 2.0.0 already on npm has no provenance attestation, losing OIDC temporarily is not a regression.

## Test plan

- [x] CI green on this PR
- [ ] After merge: watch the new \`Publish\` workflow on \`main\`
  - If runner allocates → throttling diagnosis confirmed
  - If publish succeeds → 2.0.1 on npm via NPM_TOKEN
  - If npm rejects publish (Trusted Publisher binding mismatch) → re-bind on npm.com via browser MCP

## Type

- [x] CI / build infra
- [x] Unblock release pipeline