### PR TITLE
fix: kill catastrophic-backtracking ReDoS in Vue :class extraction

### DIFF
--- a/.changeset/gentle-news-build.md
+++ b/.changeset/gentle-news-build.md
@@ -1,0 +1,11 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Fix CodeQL `js/redos` (catastrophic-backtracking ReDoS, severity error) in the
+two Vue `:class` / `v-bind:class` extraction patterns. The previous patterns
+used a nested-quantifier shape (`[^"]*(?:'[^']*'[^"]*)*`) that allowed
+exponential backtracking on pathological input. Replaced by a flat
+`[^"]*` (and `[^']*`) negated character class. Loses support for nested
+quotes inside Vue class bindings — an extreme edge case never covered by
+existing tests; all 395 unit tests still pass.

--- a/packages/tailwindcss-obfuscator/src/extractors/jsx.ts
+++ b/packages/tailwindcss-obfuscator/src/extractors/jsx.ts
@@ -45,12 +45,19 @@ const CLASS_LIST_PATTERN = /class:list\s*=\s*\{([^}]+)\}/g;
 /**
  * Pattern to match Vue :class or v-bind:class
  * e.g., :class="{ 'bg-blue-500': isActive }", :class="['flex', active && 'bg-blue']"
- * Need to handle nested quotes - match content between outer quotes
+ *
+ * Implementation note: previous versions used a nested-quantifier pattern
+ * to support stray nested quotes inside the binding (e.g. attribute strings
+ * containing both ' and "). That pattern matched CodeQL's `js/redos`
+ * signature — the nesting (`[^"]* (...) *`) caused catastrophic
+ * backtracking on inputs like `:class="aaaa…"` with no closing quote.
+ * In Vue templates, nested quotes inside the binding value are rare and
+ * the build-time tool would already mis-parse such input. Switching to a
+ * flat negated character class fixes the ReDoS without a real regression
+ * in extraction coverage.
  */
-const VUE_CLASS_BINDING_PATTERN_DOUBLE =
-  /(?::class|v-bind:class)\s*=\s*"([^"]*(?:'[^']*'[^"]*)*)"/g;
-const VUE_CLASS_BINDING_PATTERN_SINGLE =
-  /(?::class|v-bind:class)\s*=\s*'([^']*(?:"[^"]*"[^']*)*)'/g;
+const VUE_CLASS_BINDING_PATTERN_DOUBLE = /(?::class|v-bind:class)\s*=\s*"([^"]*)"/g;
+const VUE_CLASS_BINDING_PATTERN_SINGLE = /(?::class|v-bind:class)\s*=\s*'([^']*)'/g;
 
 /**
  * Pattern to match class utility function calls


### PR DESCRIPTION
## Summary

CodeQL flagged two **\`js/redos\` (severity: error)** findings in \`packages/tailwindcss-obfuscator/src/extractors/jsx.ts\`:51 and :53. Both are textbook catastrophic-backtracking ReDoS in the Vue \`:class\` / \`v-bind:class\` extraction patterns.

\`\`\`js
// BEFORE (vulnerable)
/(?::class|v-bind:class)\s*=\s*"([^\"]*(?:'[^']*'[^\"]*)*)\"/g

// AFTER (flat — no nested quantifier)
/(?::class|v-bind:class)\s*=\s*"([^\"]*)\"/g
\`\`\`

The nested \`[^\"]*\` inside a \`(?:…)*\` whose body also ends with \`[^\"]*\` is the classic catastrophic-backtracking trap. Pathological input like \`:class=\"aaaaaaaaaa…\` (no closing quote) made the regex engine try every possible split between the two quantifiers — exponential blowup.

## Why it matters

The obfuscator runs at build time on developer-controlled source — but a malicious or malformed file in a downstream user's source tree would currently freeze their build process indefinitely. Per the new **ULTRA-IMPORTANT security rule** added to \`CLAUDE.md\` this session, shipping a regex with a known ReDoS to production is not acceptable.

## Trade-off

The flat pattern no longer extracts Vue bindings with literal nested quotes (\`:class=\"aria-label='hello' bg-blue-500\"\`). This was already an unsupported corner case — no existing test covered it, and it's virtually never written in practice. The realistic Vue patterns (object syntax \`:class=\"{ 'bg-blue-500': isActive }\"\`, array syntax) all continue to work.

## Verification

- ✅ All 395 unit tests pass (\`pnpm test\`)
- ✅ Typecheck green (\`pnpm typecheck\`)
- ✅ \`pnpm audit\` count unchanged (no new advisories introduced)
- ✅ Existing Vue \`:class\` tests in \`tests/comprehensive-patterns.test.ts\` (lines 575–593) still pass — the pattern still handles the realistic case.

## Type

- [x] Bug fix
- [x] Security fix (CodeQL severity: error)

## Changeset

\`patch\` — included.