### PR TITLE
ci(publish): drop NPM_TOKEN to force OIDC-only auth

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,5 +85,12 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # NPM_TOKEN deliberately dropped: with Trusted Publisher (OIDC)
+          # active on npm for this package, the presence of NPM_TOKEN in the
+          # env causes npm to silently prefer the classic-token auth path
+          # (which lacks publish scope under the new TP rules) and rejects
+          # the PUT with a 404 "Not Found" — even though the OIDC provenance
+          # statement is correctly signed and submitted to Sigstore. Removing
+          # the token forces pnpm to fall through to OIDC-only auth, which
+          # the configured TP binding (publish.yml on main, no env) accepts.
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary

Three consecutive publish runs failed with deterministic \`E404 Not Found - PUT\` from npm despite the OIDC provenance statement being correctly signed and submitted to Sigstore. The npm Trusted Publisher binding has been verified correct (repo, workflow, no env).

The 404 is npm's opaque way to signal auth failure. The most likely cause: with Trusted Publisher active AND \`NPM_TOKEN\` passed in the env, the npm CLI prefers the classic-token path and silently bypasses OIDC. Under post-TP-activation rules, the classic NPM_TOKEN no longer has publish scope, so the PUT fails.

Removing \`NPM_TOKEN\` forces pnpm to fall through to OIDC-only, which the TP binding accepts.

## If this fails

Next pivot is \`NPM_TOKEN\`-only without provenance (Plan B), which temporarily sacrifices the Signed-Releases Scorecard score but unblocks publication. We'd then re-enable provenance separately.

## Type

- [x] CI / build infra
- [x] Unblock release pipeline