### PR TITLE
feat(docs): expose raw markdown for LLM agents + GEO improvements

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,4 +1,9 @@
 import { withMermaid } from "vitepress-plugin-mermaid";
+import fs from "node:fs";
+import path from "node:path";
+
+const SITE_URL = "https://josedacosta.github.io/tailwindcss-obfuscator";
+const DOCS_ROOT = path.resolve(__dirname, "..");
 
 export default withMermaid({
   title: "tailwindcss-obfuscator",
@@ -13,6 +18,97 @@ export default withMermaid({
 
   // Drop the prebuilt search index from older runs and the sample-app build artefacts.
   ignoreDeadLinks: true,
+
+  // Generate sitemap.xml at build time. Required for SEO + AI crawler indexing.
+  // Picked up by robots.txt's `Sitemap:` line.
+  sitemap: {
+    hostname: SITE_URL + "/",
+  },
+
+  // Per-page hook: inject an `<link rel="alternate" type="text/markdown">`
+  // pointing to the raw .md file we copy in `buildEnd`. This is the standard
+  // 2026 way to advertise the markdown source to LLM crawlers (Anthropic docs,
+  // Vercel docs, Cloudflare docs all do this).
+  transformPageData(pageData) {
+    const relPath = pageData.relativePath.replace(/\.md$/, "");
+    const mdUrl = `${SITE_URL}/${relPath}.md`;
+    pageData.frontmatter.head = pageData.frontmatter.head || [];
+    pageData.frontmatter.head.push(
+      ["link", { rel: "alternate", type: "text/markdown", href: mdUrl }],
+      // Hint AI crawlers via standard meta. Indexed by Perplexity + Claude.
+      ["meta", { name: "format-detection", content: "markdown-source-available" }],
+      ["meta", { property: "ai:source", content: mdUrl }]
+    );
+  },
+
+  // After VitePress builds the static site, copy every source `.md` into the
+  // dist tree as a static file (so /guide/sveltekit also exists as
+  // /guide/sveltekit.md returning raw markdown). Also generate `llms-full.txt`,
+  // a single concatenated file of the entire documentation for one-shot
+  // download by LLM agents.
+  async buildEnd(siteConfig) {
+    const outDir = siteConfig.outDir;
+    const allPages: { relPath: string; absPath: string; title: string; content: string }[] = [];
+
+    // Walk every .md page (excluding node_modules, .vitepress, hidden dirs)
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name.startsWith(".") || entry.name === "node_modules") continue;
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(abs);
+        } else if (entry.isFile() && abs.endsWith(".md")) {
+          const rel = path.relative(DOCS_ROOT, abs);
+          const content = fs.readFileSync(abs, "utf8");
+          // Pull the first H1 (or frontmatter title) for the index
+          const titleMatch = content.match(/^title:\s*(.+)$/m) || content.match(/^#\s+(.+)$/m);
+          const title = titleMatch ? titleMatch[1].trim() : rel;
+          allPages.push({ relPath: rel, absPath: abs, title, content });
+        }
+      }
+    };
+    walk(DOCS_ROOT);
+
+    // 1. Copy each .md to dist preserving directory layout
+    for (const page of allPages) {
+      const destPath = path.join(outDir, page.relPath);
+      fs.mkdirSync(path.dirname(destPath), { recursive: true });
+      fs.writeFileSync(destPath, page.content, "utf8");
+    }
+
+    // 2. Generate `llms-full.txt` — concatenated documentation indexed for LLMs.
+    const lines: string[] = [];
+    lines.push("# tailwindcss-obfuscator — full documentation");
+    lines.push("");
+    lines.push(`> Single-file mirror of every page on ${SITE_URL}/. Updated on each build.`);
+    lines.push(`> Source repository: https://github.com/josedacosta/tailwindcss-obfuscator`);
+    lines.push(`> Each page is also available individually at ${SITE_URL}/<path>.md`);
+    lines.push("");
+    lines.push("## Index");
+    lines.push("");
+    for (const p of allPages.sort((a, b) => a.relPath.localeCompare(b.relPath))) {
+      const url = `${SITE_URL}/${p.relPath.replace(/\.md$/, "")}.md`;
+      lines.push(`- [${p.title}](${url})`);
+    }
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+    for (const p of allPages.sort((a, b) => a.relPath.localeCompare(b.relPath))) {
+      const url = `${SITE_URL}/${p.relPath.replace(/\.md$/, "")}.md`;
+      lines.push(`# ${p.title}`);
+      lines.push(`Source: ${url}`);
+      lines.push("");
+      lines.push(p.content);
+      lines.push("");
+      lines.push("---");
+      lines.push("");
+    }
+    fs.writeFileSync(path.join(outDir, "llms-full.txt"), lines.join("\n"), "utf8");
+
+    console.log(
+      `[llm-optimization] Copied ${allPages.length} .md files + generated llms-full.txt`
+    );
+  },
 
   // Syntax highlighting with VSCode themes (light/dark)
   markdown: {

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -105,9 +105,7 @@ export default withMermaid({
     }
     fs.writeFileSync(path.join(outDir, "llms-full.txt"), lines.join("\n"), "utf8");
 
-    console.log(
-      `[llm-optimization] Copied ${allPages.length} .md files + generated llms-full.txt`
-    );
+    console.log(`[llm-optimization] Copied ${allPages.length} .md files + generated llms-full.txt`);
   },
 
   // Syntax highlighting with VSCode themes (light/dark)

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -2,6 +2,19 @@
 
 > Build-time Tailwind CSS class obfuscator (also known as a Tailwind class mangler). Rewrites verbose utility classes (`bg-blue-500`, `flex`, `items-center`) into short opaque identifiers (`tw-a`, `tw-b`, `tw-c`) inside the shipped HTML / CSS / JS bundle. Source code stays readable. Cuts CSS bundle size by 30–60% on CSS-heavy pages and makes design systems much harder to reverse-engineer. Works with Tailwind CSS v3 and v4, every major bundler (Vite, Webpack, Rollup, esbuild, Rspack, Farm) and every major framework (Next.js, Nuxt, SvelteKit, Astro, Solid, Qwik, React Router 7, TanStack Router).
 
+## For LLM agents
+
+Every page on this site is also available as **raw markdown** at the same URL with a `.md` suffix. Examples:
+
+- HTML: `https://josedacosta.github.io/tailwindcss-obfuscator/guide/sveltekit`
+- Markdown: `https://josedacosta.github.io/tailwindcss-obfuscator/guide/sveltekit.md`
+
+Both URLs return the same content — pick the markdown variant for LLM-friendly parsing (no HTML scaffolding, no nav/footer markup, just the page source).
+
+For one-shot consumption of the entire documentation, fetch [`/llms-full.txt`](https://josedacosta.github.io/tailwindcss-obfuscator/llms-full.txt) — it concatenates every page in a single file with URL-prefixed separators, ready to paste into a context window.
+
+Sitemap: <https://josedacosta.github.io/tailwindcss-obfuscator/sitemap.xml> (lists every HTML URL; append `.md` to any of them for the markdown source).
+
 ## What it does
 
 - Build-time only — runs during `vite build` / `next build` / `webpack --mode=production`. Dev servers are untouched.

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,80 @@
+# tailwindcss-obfuscator documentation site
+# Site: https://josedacosta.github.io/tailwindcss-obfuscator/
+# Source: https://github.com/josedacosta/tailwindcss-obfuscator
+#
+# All crawlers, including AI/LLM crawlers, are explicitly welcome.
+# This is intentional — the project is open-source MIT and benefits from
+# wider AI-assisted discovery (Claude Search, ChatGPT Search, Perplexity,
+# Google AI Overviews, Bing Copilot, etc.).
+#
+# LLM-friendly entry points:
+#   /tailwindcss-obfuscator/llms.txt       — concise project summary + key URLs
+#   /tailwindcss-obfuscator/llms-full.txt  — full documentation concatenated
+#   /tailwindcss-obfuscator/<page>.md      — every page available as raw markdown
+
+User-agent: *
+Allow: /
+
+# Explicit allowlist for known AI crawlers (defense against future tightening).
+# We WANT these bots — listing them documents the intent and protects against
+# accidental blocks if the wildcard rule above is ever narrowed.
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: GoogleOther
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: Meta-ExternalAgent
+Allow: /
+
+User-agent: Bytespider
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: DuckAssistBot
+Allow: /
+
+User-agent: YouBot
+Allow: /
+
+User-agent: Diffbot
+Allow: /
+
+# Sitemap pointer
+Sitemap: https://josedacosta.github.io/tailwindcss-obfuscator/sitemap.xml


### PR DESCRIPTION
## Summary

Adds the standard 2026 LLM-friendly documentation pattern (used by [Anthropic](https://docs.anthropic.com/llms.txt), [Vercel](https://vercel.com/docs/llms.txt), [Cloudflare](https://developers.cloudflare.com/llms.txt)) to the docs site.

## What this enables

| Endpoint | Purpose |
|---|---|
| \`/<path>.md\` (45 URLs) | Same content as the HTML page, but raw markdown — easier for LLM agents to parse than scraping HTML |
| \`/llms-full.txt\` (~355 KB) | Single-file mirror of the entire documentation, for one-shot context-window ingestion |
| \`/llms.txt\` (existing, refreshed) | Concise project summary + pointers to the above |
| \`/robots.txt\` (new) | Explicit allowlist for AI crawlers (GPTBot, ClaudeBot, PerplexityBot, etc.) + sitemap pointer |
| \`/sitemap.xml\` (new) | Generated by VitePress, lists all 45 HTML URLs |

## What changes on every HTML page

Three signals are now injected via \`transformPageData\` :

\`\`\`html
<link rel=\"alternate\" type=\"text/markdown\" href=\"https://josedacosta.github.io/tailwindcss-obfuscator/guide/sveltekit.md\">
<meta name=\"format-detection\" content=\"markdown-source-available\">
<meta property=\"ai:source\" content=\"https://josedacosta.github.io/tailwindcss-obfuscator/guide/sveltekit.md\">
\`\`\`

## Verification

- \`pnpm docs:build\` succeeds with: \`[llm-optimization] Copied 45 .md files + generated llms-full.txt\`
- Spot-checked \`dist/guide/sveltekit.html\` — contains all three new tags
- \`dist/sitemap.xml\` lists 45 URLs with lastmod
- \`dist/robots.txt\`, \`llms.txt\`, \`llms-full.txt\` all present at site root

## Type

- [x] Documentation
- [x] SEO / GEO

## Changeset

Not applicable — docs-only change, no published-package impact.