### PR TITLE
chore(release): version packages — bump to 2.0.3 (pipeline validation)

### DIFF
--- a/packages/tailwindcss-obfuscator/CHANGELOG.md
+++ b/packages/tailwindcss-obfuscator/CHANGELOG.md
@@ -1,5 +1,24 @@
 # tailwindcss-obfuscator
 
+## 2.0.3
+
+### Patch Changes
+
+- Internal release pipeline validation — no consumer-visible code change.
+
+  This patch is published to validate that the npm OIDC trusted-publishing
+  pipeline now succeeds end-to-end via GitHub Actions, after the npm-side
+  Trusted Publisher binding was rebound to `publish.yml` and the workflow
+  itself was hardened (PRs #44, #47, #49). It also implicitly ships the
+  internal CI improvements accumulated since 2.0.2 :
+  - npm runner upgraded to latest (11.5.1+) for stable OIDC support
+  - `NPM_CONFIG_PROVENANCE` env var dropped (redundant with OIDC trusted publishing)
+  - `NPM_TOKEN` removed from publish workflow (forces clean OIDC-only auth)
+  - `release.yml` renamed to `publish.yml` (bypasses the deployment-throttling lock)
+
+  Library API and behaviour are unchanged. Upgrading from 2.0.2 → 2.0.3
+  requires no action on the consumer side.
+
 ## 2.0.2
 
 ### Patch Changes

--- a/packages/tailwindcss-obfuscator/package.json
+++ b/packages/tailwindcss-obfuscator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwindcss-obfuscator",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Obfuscate Tailwind CSS class names at build time. Vite, Webpack, Rollup, esbuild, Next.js, Nuxt, SvelteKit, Astro, Solid, Qwik, React Router 7, TanStack Router. Tailwind v3 + v4.",
   "author": {
     "name": "José DA COSTA",


### PR DESCRIPTION
## Summary

Forced patch release \`2.0.3\` to validate that the npm OIDC trusted-publishing pipeline now succeeds end-to-end via GitHub Actions, after :

- npm-side TP binding rebound to \`publish.yml\` (manually by maintainer)
- Workflow renamed \`release.yml\` → \`publish.yml\` (PR #44, bypasses GHA throttling)
- \`NPM_TOKEN\` removed (PR #47, OIDC-only auth)
- npm runner upgraded + redundant flags dropped (PR #49)

## Hypothesis under test (LL-2026-04-29-C)

The 7 OIDC publish runs that returned 404 on 2026-04-29 morning were caused by a stale npm-side Trusted Publisher matcher cache. The WebAuthn local publish at 12:20 UTC may have flushed that cache. **This release will confirm or invalidate that hypothesis.**

- ✅ Workflow succeeds → hypothesis confirmed; document as standard remediation in \`jose/scripts/npm/browser-manual.md\`
- ❌ 404 again → strong evidence for npm support ticket; we'd ship 2.0.3 via local WebAuthn (Recipe Variant B in the manual)

## What changes for users

**Nothing.** No \`src/\` modifications between 2.0.2 and 2.0.3 — only internal CI cleanup is bundled in the changeset summary.

## Type

- [x] Release / version bump
- [x] Pipeline validation