### PR TITLE
chore(project): map labs folder + add pnpm audit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,28 @@ jobs:
           name: dist
           path: packages/tailwindcss-obfuscator/dist
           retention-days: 7
+
+  audit:
+    # Belt-and-suspenders: Renovate already opens PRs for vulnerable transitive
+    # deps and `pnpm.overrides` patches them on the spot, but we also want a
+    # blocking CI gate so that any PR which would re-introduce a high/critical
+    # advisory cannot land. Threshold matches the project security rule in
+    # CLAUDE.md ("Never ship a PR that increases the audit count").
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: pnpm audit (high+critical fail the build)
+        run: pnpm audit --audit-level=high

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -249,6 +249,20 @@ export default withMermaid({
             { text: "Tailwind Design System", link: "/reference/tailwind-design-system" },
           ],
         },
+        {
+          text: "Labs (validation reports)",
+          collapsed: true,
+          items: [
+            {
+              text: "Tailwind v3 — install guide",
+              link: "/reference/labs/lab_tw3_installation_guide",
+            },
+            { text: "Tailwind v3 — HTML static", link: "/reference/labs/tailwind-v3-html" },
+            { text: "Tailwind v3 — Next.js", link: "/reference/labs/tailwind-v3-nextjs" },
+            { text: "Tailwind v4 — HTML static", link: "/reference/labs/tailwind-v4-html" },
+            { text: "Tailwind v4 — Next.js", link: "/reference/labs/tailwind-v4-nextjs" },
+          ],
+        },
       ],
       "/research/": [
         {


### PR DESCRIPTION
Two small high-value findings from the project sweep:
1. `docs/reference/labs/` (5 files) was orphaned — now reachable via a new "Labs (validation reports)" sidebar section under `/reference/`.
2. New CI `audit` job runs `pnpm audit --audit-level=high` (failure-blocking) — belt-and-suspenders alongside Renovate + `pnpm.overrides`. Matches the ULTRA-IMPORTANT security rule in CLAUDE.md.

No `src/**` change, no changeset required.