### PR TITLE
feat(apps): test-safelist app validating exclude (safelist) option

### DIFF
--- a/apps/test-safelist/build.js
+++ b/apps/test-safelist/build.js
@@ -1,0 +1,123 @@
+// Build the test-safelist app and verify the obfuscator's `exclude` option
+// (a.k.a. safelist behaviour) keeps the listed class names unchanged in the
+// emitted HTML and CSS.
+//
+// Mirrors the structure of apps/test-static-html/build.js and adds the
+// `exclude` config block. After build, runs an in-process assertion that
+// every preserved class is still present verbatim in dist/index.html and
+// dist/styles.css, and that no `tw-*` substitution leaked onto them.
+
+import * as esbuild from "esbuild";
+import * as fs from "fs";
+import {
+  createContext,
+  initializeContext,
+  saveMapping,
+  updateMappingMetadata,
+  extractClasses,
+  extractFromCssFiles,
+  transformContent,
+  createLogger,
+} from "tailwindcss-obfuscator/internals";
+
+if (!fs.existsSync("dist")) {
+  fs.mkdirSync("dist", { recursive: true });
+}
+
+await esbuild.build({
+  entryPoints: ["src/main.js"],
+  bundle: true,
+  outfile: "dist/main.js",
+  format: "esm",
+});
+
+// Real Tailwind utilities that we list in `exclude` to test the option for real.
+// Tailwind WILL generate CSS for these (so the post-build CSS check is meaningful)
+// and the obfuscator MUST keep them verbatim despite their being eligible.
+const PRESERVED_LITERALS = ["bg-red-500", "text-yellow-300", "font-bold"];
+const REGEX_PATTERN_PRESERVED = ["text-emerald-700", "text-emerald-900"]; // matched by /^text-emerald-/
+
+const ctx = createContext(
+  {
+    prefix: "tw-",
+    verbose: true,
+    debug: true,
+    content: ["src/**/*.html"],
+    css: ["dist/styles.css"],
+    mapping: { enabled: true, file: ".tw-obfuscation/class-mapping.json" },
+    // The behaviour under test : both literal-string entries and a regex
+    // pattern entry must be honoured. Anything matched here MUST appear
+    // verbatim in the post-build HTML/CSS.
+    exclude: [...PRESERVED_LITERALS, /^text-emerald-/],
+  },
+  "production"
+);
+
+const logger = createLogger(true, true);
+const basePath = process.cwd();
+
+initializeContext(ctx, basePath, logger);
+await extractClasses(ctx, basePath, logger);
+await extractFromCssFiles(ctx, basePath, logger);
+updateMappingMetadata(ctx, ctx.detectedTailwindVersion || "unknown");
+
+const htmlSrc = fs.readFileSync("src/index.html", "utf-8");
+const htmlOut = transformContent(htmlSrc, "src/index.html", ctx);
+fs.writeFileSync("dist/index.html", htmlOut.transformed);
+console.log(`HTML: ${htmlOut.replacements} replacements`);
+
+const cssPath = "dist/styles.css";
+if (fs.existsSync(cssPath)) {
+  const cssSrc = fs.readFileSync(cssPath, "utf-8");
+  const cssOut = transformContent(cssSrc, cssPath, ctx);
+  fs.writeFileSync(cssPath, cssOut.transformed);
+  console.log(`CSS:  ${cssOut.replacements} replacements`);
+}
+
+saveMapping(ctx, basePath);
+
+// === Assertions: the safelist behaviour MUST hold post-build ===
+const builtHtml = fs.readFileSync("dist/index.html", "utf-8");
+const builtCss = fs.existsSync(cssPath) ? fs.readFileSync(cssPath, "utf-8") : "";
+const allClassesToCheck = [...PRESERVED_LITERALS, ...REGEX_PATTERN_PRESERVED];
+
+let failed = 0;
+for (const cls of allClassesToCheck) {
+  if (!builtHtml.includes(cls)) {
+    console.error(
+      `❌ FAIL: "${cls}" missing from dist/index.html (was obfuscated against the exclude rule)`
+    );
+    failed++;
+  }
+  // CSS check: same class must still produce a `.<cls>` selector in the
+  // emitted stylesheet (not rewritten to `.tw-XXX`).
+  if (builtCss && !builtCss.includes(`.${cls}`)) {
+    console.error(
+      `❌ FAIL: ".${cls}" CSS selector missing from dist/styles.css (rule was obfuscated against the exclude)`
+    );
+    failed++;
+  }
+}
+
+// And the mapping file must NOT contain any of the preserved classes.
+const mapPath = ".tw-obfuscation/class-mapping.json";
+if (fs.existsSync(mapPath)) {
+  const mapping = JSON.parse(fs.readFileSync(mapPath, "utf-8"));
+  const mappedClasses = Object.keys(mapping.mapping || mapping);
+  for (const cls of allClassesToCheck) {
+    if (mappedClasses.includes(cls)) {
+      console.error(`❌ FAIL: "${cls}" present in class-mapping.json — should have been excluded`);
+      failed++;
+    }
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} assertion(s) failed — exclude / safelist option is BROKEN.`);
+  process.exit(1);
+}
+
+console.log(
+  `✅ All ${allClassesToCheck.length} excluded classes preserved verbatim — safelist works.`
+);
+console.log("Build complete!");

--- a/apps/test-safelist/package.json
+++ b/apps/test-safelist/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "test-safelist",
+  "version": "1.0.0",
+  "description": "Test app exercising the obfuscator's `exclude` option (a.k.a. safelist) — classes listed in `exclude` MUST remain unchanged in the output",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:css": "npx @tailwindcss/cli -i ./src/input.css -o ./dist/styles.css",
+    "build:js": "node build.js",
+    "build": "pnpm build:css && pnpm build:js",
+    "dev": "pnpm build && npx serve dist"
+  },
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.2.4",
+    "tailwindcss": "^4.2.4",
+    "esbuild": "^0.28.0",
+    "serve": "^14.2.4",
+    "tailwindcss-obfuscator": "workspace:*"
+  }
+}

--- a/apps/test-safelist/src/index.html
+++ b/apps/test-safelist/src/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>tailwindcss-obfuscator — safelist (`exclude`) integration test</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body class="bg-slate-50 p-8 font-sans text-slate-900">
+    <main class="mx-auto max-w-3xl space-y-6">
+      <header>
+        <h1 class="text-3xl font-bold">Safelist test app</h1>
+        <p class="text-sm text-slate-600">
+          Classes inside <code class="rounded bg-slate-200 px-1">exclude</code> MUST stay unchanged.
+          Everything else MUST be obfuscated to <code>tw-XXX</code>.
+        </p>
+      </header>
+
+      <!-- These are real Tailwind utilities listed in the obfuscator's `exclude`
+           array (build.js). Post-build, they MUST appear unchanged in both
+           dist/index.html and dist/styles.css. The string-literal entries
+           (bg-red-500, text-yellow-300, font-bold) test exact-match exclusion;
+           text-emerald-700 + text-emerald-900 test regex exclusion via
+           /^text-emerald-/ which the build.js config registers. -->
+      <section class="rounded border border-blue-300 bg-blue-50 p-4">
+        <h2 class="mb-2 text-xl font-semibold">Preserved classes (must stay verbatim)</h2>
+        <p class="bg-red-500 px-3 py-2 text-yellow-300">
+          bg-red-500 + text-yellow-300 (string-literal exclude)
+        </p>
+        <p class="font-bold">font-bold (string-literal exclude)</p>
+        <p class="text-emerald-700">text-emerald-700 (regex exclude /^text-emerald-/)</p>
+        <p class="text-emerald-900">text-emerald-900 (regex exclude /^text-emerald-/)</p>
+      </section>
+
+      <!-- Regular Tailwind classes — these MUST be obfuscated to tw-XXX. -->
+      <section class="rounded border border-blue-200 bg-emerald-50 p-4">
+        <h2 class="mb-2 text-xl font-semibold">Regular Tailwind classes (must be obfuscated)</h2>
+        <p class="text-sm">
+          The wrapping section uses <code>bg-emerald-50</code>, <code>border-blue-200</code>,
+          <code>rounded</code>, <code>p-4</code> — all of which should appear as <code>tw-XXX</code>
+          in the built HTML.
+        </p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/apps/test-safelist/src/input.css
+++ b/apps/test-safelist/src/input.css
@@ -1,0 +1,2 @@
+/* Tailwind v4 CSS-first configuration */
+@import "tailwindcss";

--- a/apps/test-safelist/src/main.js
+++ b/apps/test-safelist/src/main.js
@@ -1,0 +1,4 @@
+// Empty entry — this app validates the safelist (`exclude`) behaviour and has
+// no JavaScript runtime concerns. The interesting bits are in src/index.html
+// (classes that should stay) and build.js (the `exclude` configuration).
+console.log("test-safelist: HTML/CSS-only app, JS bundle intentionally empty");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,6 +707,24 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tailwindcss-obfuscator
 
+  apps/test-safelist:
+    devDependencies:
+      '@tailwindcss/cli':
+        specifier: ^4.2.4
+        version: 4.2.4
+      esbuild:
+        specifier: '>=0.25.0'
+        version: 0.28.0
+      serve:
+        specifier: ^14.2.4
+        version: 14.2.5
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      tailwindcss-obfuscator:
+        specifier: workspace:*
+        version: link:../../packages/tailwindcss-obfuscator
+
   apps/test-shadcn-ui:
     dependencies:
       '@hookform/resolvers':


### PR DESCRIPTION
Adds `apps/test-safelist/` exercising the obfuscator's `exclude` option end-to-end with both string-literal entries (`bg-red-500`, `text-yellow-300`, `font-bold`) and a regex pattern (`/^text-emerald-/` matching `text-emerald-700`, `text-emerald-900`). Build script self-asserts that all 5 preserved classes survive verbatim in the output HTML/CSS and are absent from class-mapping.json. `scripts/verify-obfuscation.mjs` picks the app up automatically (18 apps now, all green). Closes part of issue #55.