### PR TITLE
fix: extract tv() (tailwind-variants) base + variants + compoundVariants (#61)

### DIFF
--- a/.changeset/fix-tv-extractor.md
+++ b/.changeset/fix-tv-extractor.md
@@ -1,0 +1,11 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Fix #61 — `tv()` (tailwind-variants) extractor was silently broken: classes inside `tv({ base, variants, compoundVariants, slots })` were not being extracted, leaving them un-obfuscated in production bundles. Two root causes :
+
+1. **Registry routing**: `extractors/index.ts` mapped `js/jsx/ts/tsx/vue/svelte/astro` to `extractFromJsxWithCva` (which only handles `cva()`), bypassing `extractAllFromJsx` which composes the cn/cva/tv extractors. Now every JS-family extension uses `extractAllFromJsx`.
+
+2. **Nested-object regex**: the `tv()` variants regex used `[\s\S]*?\}` which closes on the first inner `}` (e.g. `intent: { primary }` truncates after `primary`). Refactored `extractFromTailwindVariants` to use `extractBalancedBlock` for `variants`, `slots`, `compoundVariants`, `compoundSlots`, and `defaultVariants` — the same balanced-brace approach `cva()` already used.
+
+The README claim "Recognises `tv()` out of the box" now holds end-to-end. New `apps/test-tailwind-variants/` regression test asserts that all 33 expected tv() classes (base + variants + compoundVariants across 2 tv() instances) appear in the post-build mapping.

--- a/apps/test-tailwind-variants/package.json
+++ b/apps/test-tailwind-variants/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "test-tailwind-variants",
+  "version": "1.0.0",
+  "description": "Test app validating that the obfuscator extracts and obfuscates classes inside tv() (tailwind-variants) base / variants / compoundVariants — regression coverage for issue #61",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rollup -c"
+  },
+  "devDependencies": {
+    "@rollup/plugin-html": "^2.0.0",
+    "@rollup/plugin-node-resolve": "^16.0.0",
+    "@tailwindcss/postcss": "^4.2.4",
+    "postcss": "^8.5.12",
+    "rollup": "^4.60.2",
+    "rollup-plugin-postcss": "^4.0.2",
+    "tailwind-variants": "^0.3.0",
+    "tailwindcss": "^4.2.4",
+    "tailwindcss-obfuscator": "workspace:*"
+  }
+}

--- a/apps/test-tailwind-variants/rollup.config.js
+++ b/apps/test-tailwind-variants/rollup.config.js
@@ -1,0 +1,115 @@
+import nodeResolve from "@rollup/plugin-node-resolve";
+import postcss from "rollup-plugin-postcss";
+import html from "@rollup/plugin-html";
+import tailwindcssPostcss from "@tailwindcss/postcss";
+import tailwindcssObfuscator from "tailwindcss-obfuscator/rollup";
+import * as fs from "fs";
+
+// Build with the obfuscator, then assert that every tv() class survived
+// obfuscation (i.e. no raw Tailwind utility leaks into the bundled JS or CSS).
+// This is the regression check for issue #61.
+
+const TV_CLASSES_TO_VERIFY = [
+  // base
+  "inline-flex",
+  "items-center",
+  "justify-center",
+  "rounded",
+  "font-semibold",
+  "transition-colors",
+  // variants.intent
+  "bg-blue-600",
+  "text-white",
+  "hover:bg-blue-700",
+  "bg-red-600",
+  "hover:bg-red-700",
+  "bg-transparent",
+  "text-blue-600",
+  "hover:bg-blue-50",
+  // variants.size
+  "px-3",
+  "py-1.5",
+  "text-sm",
+  "px-4",
+  "py-2",
+  "text-base",
+  "px-6",
+  "py-3",
+  "text-lg",
+  // compoundVariants
+  "shadow-lg",
+  "shadow-blue-500/30",
+  // card.base + variants
+  "rounded-lg",
+  "border-slate-200",
+  "bg-white",
+  "p-6",
+  "shadow-md",
+  "shadow-xl",
+  "ring-1",
+  "ring-slate-100",
+];
+
+export default {
+  input: "src/main.js",
+  output: {
+    dir: "dist",
+    format: "es",
+    entryFileNames: "[name]-[hash].js",
+    assetFileNames: "[name]-[hash][extname]",
+  },
+  plugins: [
+    nodeResolve(),
+    postcss({ extract: "style.css", plugins: [tailwindcssPostcss()] }),
+    html({
+      title: "tv() obfuscation regression test (#61)",
+      template: ({ files, title }) => {
+        const cssLink = (files.css || [])
+          .map((c) => `<link rel="stylesheet" href="./${c.fileName}">`)
+          .join("\n    ");
+        const jsScripts = (files.js || [])
+          .map((c) => `<script type="module" src="./${c.fileName}"></script>`)
+          .join("\n    ");
+        return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>${title}</title>
+    ${cssLink}
+  </head>
+  <body>
+    <div id="app"></div>
+    ${jsScripts}
+  </body>
+</html>`;
+      },
+    }),
+    tailwindcssObfuscator({
+      prefix: "tw-",
+      verbose: true,
+      debug: true,
+      content: ["src/**/*.{html,js,jsx,ts,tsx}"],
+      css: ["src/**/*.css"],
+      mapping: { enabled: true, file: ".tw-obfuscation/class-mapping.json", pretty: 2 },
+    }),
+    {
+      name: "tv-regression-assertions",
+      writeBundle() {
+        const map = JSON.parse(fs.readFileSync(".tw-obfuscation/class-mapping.json", "utf8"));
+        const mapped = Object.keys(map.classes || {});
+        const missing = TV_CLASSES_TO_VERIFY.filter((c) => !mapped.includes(c));
+        if (missing.length > 0) {
+          console.error(`\n❌ FAIL: ${missing.length} tv() classes were NOT extracted:\n`);
+          for (const c of missing) console.error(`   - ${c}`);
+          console.error(
+            "\nThis means the tv() extractor (#61) regressed. Check packages/tailwindcss-obfuscator/src/extractors/jsx.ts:extractFromTailwindVariants."
+          );
+          process.exit(1);
+        }
+        console.log(
+          `\n✅ PASS: all ${TV_CLASSES_TO_VERIFY.length} tv() classes (base + variants + compoundVariants) extracted and obfuscated.`
+        );
+      },
+    },
+  ],
+};

--- a/apps/test-tailwind-variants/src/main.js
+++ b/apps/test-tailwind-variants/src/main.js
@@ -1,0 +1,55 @@
+import "./style.css";
+import { tv } from "tailwind-variants";
+
+// Regression test for issue #61 : the obfuscator MUST extract and obfuscate
+// every class string inside a tv() call's base / variants / compoundVariants.
+// Before the fix, only the inline template-literal classes at the bottom were
+// obfuscated and the entire tv() body shipped raw to production.
+
+const button = tv({
+  base: "inline-flex items-center justify-center rounded font-semibold transition-colors",
+  variants: {
+    intent: {
+      primary: "bg-blue-600 text-white hover:bg-blue-700",
+      danger: "bg-red-600 text-white hover:bg-red-700",
+      ghost: "bg-transparent text-blue-600 hover:bg-blue-50",
+    },
+    size: {
+      sm: "px-3 py-1.5 text-sm",
+      md: "px-4 py-2 text-base",
+      lg: "px-6 py-3 text-lg",
+    },
+  },
+  compoundVariants: [{ intent: "primary", size: "lg", class: "shadow-lg shadow-blue-500/30" }],
+  defaultVariants: { intent: "primary", size: "md" },
+});
+
+const card = tv({
+  base: "rounded-lg border border-slate-200 bg-white p-6 shadow-md",
+  variants: { elevated: { true: "shadow-xl ring-1 ring-slate-100" } },
+});
+
+const root = document.getElementById("app");
+root.innerHTML = `
+  <main class="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 px-4 py-12">
+    <div class="mx-auto max-w-3xl space-y-6">
+      <h1 class="text-4xl font-extrabold text-slate-900 mb-2">tailwind-variants regression test (#61)</h1>
+      <p class="text-slate-600 mb-6">
+        Every <code>tv()</code> base/variant/compoundVariant string above
+        should appear as <code>tw-XXX</code> in the bundle. If you see raw
+        Tailwind class names in the rendered DOM, the obfuscator missed them.
+      </p>
+
+      <div class="${card({ elevated: true })}">
+        <h2 class="text-2xl font-bold mb-4">Buttons</h2>
+        <div class="flex flex-wrap gap-3">
+          <button class="${button({ intent: "primary", size: "sm" })}">Primary sm</button>
+          <button class="${button({ intent: "primary", size: "md" })}">Primary md</button>
+          <button class="${button({ intent: "primary", size: "lg" })}">Primary lg (compound)</button>
+          <button class="${button({ intent: "danger", size: "md" })}">Danger</button>
+          <button class="${button({ intent: "ghost", size: "md" })}">Ghost</button>
+        </div>
+      </div>
+    </div>
+  </main>
+`;

--- a/apps/test-tailwind-variants/src/style.css
+++ b/apps/test-tailwind-variants/src/style.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/packages/tailwindcss-obfuscator/src/extractors/index.ts
+++ b/packages/tailwindcss-obfuscator/src/extractors/index.ts
@@ -8,29 +8,39 @@ import fg from "fast-glob";
 import type { ExtractionResult, ExtractorFn, PluginContext, Logger } from "../core/types.js";
 import { addClasses } from "../core/context.js";
 import { extractFromHtml } from "./html.js";
-import { extractFromJsx, extractFromJsxWithCva } from "./jsx.js";
+import { extractAllFromJsx } from "./jsx.js";
 import { extractFromCss, extractFromTailwindV4Css, detectTailwindVersion } from "./css.js";
 import { deduplicateClasses } from "./base.js";
 
 export { extractFromHtml, extractFromHtmlAggressive } from "./html.js";
-export { extractFromJsx, extractFromJsxWithCva } from "./jsx.js";
+export {
+  extractFromJsx,
+  extractFromJsxWithCva,
+  extractAllFromJsx,
+  extractFromTailwindVariants,
+} from "./jsx.js";
 export { extractFromCss, extractFromTailwindV4Css, detectTailwindVersion } from "./css.js";
 export * from "./base.js";
 
 /**
- * Map file extensions to extractors
+ * Map file extensions to extractors. Every JS-family extension uses
+ * `extractAllFromJsx` (which composes `extractFromJsx` + `extractFromJsxWithCva`
+ * + `extractFromTailwindVariants`) so that classes inside `cn()`, `clsx()`,
+ * `cva()`, AND `tv()` are picked up uniformly. Before fix #61, `tv()` was
+ * registered as a separate extractor that was never invoked, leaving
+ * `tailwind-variants` users with un-obfuscated bundles.
  */
 const EXTRACTOR_MAP: Record<string, ExtractorFn> = {
   html: extractFromHtml,
   htm: extractFromHtml,
   css: extractFromCss,
-  js: extractFromJsx,
-  jsx: extractFromJsxWithCva,
-  ts: extractFromJsx,
-  tsx: extractFromJsxWithCva,
-  vue: extractFromJsx, // Vue uses similar syntax
-  svelte: extractFromJsx, // Svelte uses class:
-  astro: extractFromJsx, // Astro uses className
+  js: extractAllFromJsx,
+  jsx: extractAllFromJsx,
+  ts: extractAllFromJsx,
+  tsx: extractAllFromJsx,
+  vue: extractAllFromJsx, // Vue uses similar syntax
+  svelte: extractAllFromJsx, // Svelte uses class:
+  astro: extractAllFromJsx, // Astro uses className
 };
 
 /**

--- a/packages/tailwindcss-obfuscator/src/extractors/jsx.ts
+++ b/packages/tailwindcss-obfuscator/src/extractors/jsx.ts
@@ -379,11 +379,17 @@ export function extractFromJsxWithCva(content: string, _filePath: string): strin
 
 /**
  * Extract classes from tailwind-variants (tv) patterns
+ *
+ * Uses `extractBalancedBlock` for `variants:`, `slots:`, `compoundVariants:`,
+ * `compoundSlots:`, and `defaultVariants:` because their content is a nested
+ * object with inner braces (`intent: { primary: "..." }`). A naive regex with
+ * `[\s\S]*?\}` closes on the first inner `}` and captures only the first key,
+ * leaving the rest of the variants un-extracted (this was issue #61).
  */
 export function extractFromTailwindVariants(content: string, _filePath: string): string[] {
   const classes: string[] = [];
 
-  // Pattern for tv() base classes
+  // Pattern for tv() base classes (single string, no nested braces — regex OK).
   const tvBasePattern = /tv\s*\(\s*\{[\s\S]*?base\s*:\s*["'`]([^"'`]+)["'`]/g;
   let match;
 
@@ -393,35 +399,50 @@ export function extractFromTailwindVariants(content: string, _filePath: string):
   }
   tvBasePattern.lastIndex = 0;
 
-  // Pattern for tv() variants
-  const tvVariantsPattern = /tv\s*\(\s*\{[\s\S]*?variants\s*:\s*\{([\s\S]*?)\}\s*(?:,|\})/g;
-  while ((match = tvVariantsPattern.exec(content)) !== null) {
-    const variants = match[1];
+  // For each tv() call, find every keyword block (variants, slots,
+  // compoundVariants, compoundSlots, defaultVariants) and extract every
+  // string literal inside it via balanced-brace traversal.
+  const tvCallSitePattern = /tv\s*\(\s*\{/g;
+  while ((match = tvCallSitePattern.exec(content)) !== null) {
+    // Find the closing `}` of the tv({...}) call so we don't bleed into
+    // the next tv() block in the same file.
+    const callOpen = content.indexOf("{", match.index);
+    const callBlock = extractBalancedBlock(content, callOpen, "{", "}");
+    if (!callBlock) continue;
 
-    // Extract string values from variants
-    let stringMatch;
-    while ((stringMatch = STRING_LITERAL_PATTERN.exec(variants)) !== null) {
-      const stringValue = stringMatch[1];
-      classes.push(...extractClassesFromString(stringValue));
+    for (const keyword of [
+      "variants",
+      "slots",
+      "compoundVariants",
+      "compoundSlots",
+      "defaultVariants",
+    ]) {
+      // Find each keyword inside the tv() call. May appear once.
+      const re = new RegExp(`\\b${keyword}\\s*:`, "g");
+      let kMatch;
+      while ((kMatch = re.exec(callBlock)) !== null) {
+        // Find the next `{` or `[` after the colon and extract that balanced block.
+        const afterColon = callBlock.indexOf(":", kMatch.index) + 1;
+        // Skip whitespace, find the opening character.
+        let i = afterColon;
+        while (i < callBlock.length && /\s/.test(callBlock[i])) i++;
+        const open = callBlock[i];
+        const close = open === "[" ? "]" : open === "{" ? "}" : null;
+        if (!close) continue;
+        const block = extractBalancedBlock(callBlock, i, open, close);
+        if (!block) continue;
+        // Extract every string literal inside the block.
+        let stringMatch;
+        while ((stringMatch = STRING_LITERAL_PATTERN.exec(block)) !== null) {
+          const stringValue = stringMatch[1];
+          classes.push(...extractClassesFromString(stringValue));
+        }
+        STRING_LITERAL_PATTERN.lastIndex = 0;
+      }
     }
-    STRING_LITERAL_PATTERN.lastIndex = 0;
   }
-  tvVariantsPattern.lastIndex = 0;
-
-  // Pattern for tv() slots
-  const tvSlotsPattern = /tv\s*\(\s*\{[\s\S]*?slots\s*:\s*\{([\s\S]*?)\}\s*(?:,|\})/g;
-  while ((match = tvSlotsPattern.exec(content)) !== null) {
-    const slots = match[1];
-
-    // Extract string values from slots
-    let stringMatch;
-    while ((stringMatch = STRING_LITERAL_PATTERN.exec(slots)) !== null) {
-      const stringValue = stringMatch[1];
-      classes.push(...extractClassesFromString(stringValue));
-    }
-    STRING_LITERAL_PATTERN.lastIndex = 0;
-  }
-  tvSlotsPattern.lastIndex = 0;
+  tvCallSitePattern.lastIndex = 0;
+  // (Slots are already covered by the keyword loop above — no separate pass needed.)
 
   return deduplicateClasses(classes.filter((cls) => isTailwindClass(cls)));
 }

--- a/packages/tailwindcss-obfuscator/src/internals.ts
+++ b/packages/tailwindcss-obfuscator/src/internals.ts
@@ -72,6 +72,8 @@ export {
   extractFromHtmlAggressive,
   extractFromJsx,
   extractFromJsxWithCva,
+  extractFromTailwindVariants,
+  extractAllFromJsx,
   extractFromCss,
   extractFromTailwindV4Css,
   extractFromFile,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,7 +93,7 @@ importers:
         version: 3.4.18(tsx@4.21.0)(yaml@2.8.3)
       vite:
         specifier: '>=6.4.2'
-        version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
     devDependencies:
       '@types/jsdom':
         specifier: ^21.1.7
@@ -118,7 +118,7 @@ importers:
         version: 5.0.0(magicast@0.5.2)(rollup@4.60.2)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.1)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@22.19.1)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/tailwind_v3_react_nextjs:
     dependencies:
@@ -278,7 +278,7 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.7.0(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/ui':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
@@ -305,7 +305,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@22.19.1)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.5(@types/node@22.19.1)(@vitest/ui@4.1.5)(jsdom@25.0.1)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/tailwind_v4_html_static:
     dependencies:
@@ -1041,6 +1041,36 @@ importers:
       vite:
         specifier: '>=6.4.2'
         version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  apps/test-tailwind-variants:
+    devDependencies:
+      '@rollup/plugin-html':
+        specifier: ^2.0.0
+        version: 2.0.0(rollup@4.60.2)
+      '@rollup/plugin-node-resolve':
+        specifier: ^16.0.0
+        version: 16.0.3(rollup@4.60.2)
+      '@tailwindcss/postcss':
+        specifier: ^4.2.4
+        version: 4.2.4
+      postcss:
+        specifier: '>=8.5.6'
+        version: 8.5.12
+      rollup:
+        specifier: '>=4.59.0'
+        version: 4.60.2
+      rollup-plugin-postcss:
+        specifier: ^4.0.2
+        version: 4.0.2(postcss@8.5.12)
+      tailwind-variants:
+        specifier: ^0.3.0
+        version: 0.3.1(tailwindcss@4.2.4)
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      tailwindcss-obfuscator:
+        specifier: workspace:*
+        version: link:../../packages/tailwindcss-obfuscator
 
   apps/test-tanstack-start:
     dependencies:
@@ -10612,8 +10642,17 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
+  tailwind-merge@2.5.4:
+    resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
+
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
+
+  tailwind-variants@0.3.1:
+    resolution: {integrity: sha512-krn67M3FpPwElg4FsZrOQd0U26o7UDH/QOkK8RNaiCCrr052f6YJPBUfNKnPo/s/xRzNPtv1Mldlxsg8Tb46BQ==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwindcss: '*'
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -15885,6 +15924,18 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - rollup
+      - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
       - supports-color
 
   '@vitejs/plugin-react@4.7.0(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
@@ -22657,7 +22708,14 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
+  tailwind-merge@2.5.4: {}
+
   tailwind-merge@3.4.0: {}
+
+  tailwind-variants@0.3.1(tailwindcss@4.2.4):
+    dependencies:
+      tailwind-merge: 2.5.4
+      tailwindcss: 4.2.4
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
Closes #61. The README claim `Recognises tv() out of the box` was silently broken : classes inside `tv({ base, variants, compoundVariants })` were never extracted, shipping un-obfuscated.

**Root cause #1**: registry routed jsx/tsx to `extractFromJsxWithCva` (cva-only) instead of `extractAllFromJsx` (composes cn/cva/tv). **Fixed**.

**Root cause #2**: tv() variants regex used `[\s\S]*?\}` which closes on the first inner `}` (`intent: { primary }` truncates after primary). **Fixed** by switching to balanced-brace traversal across all 5 tv() keyword blocks (variants/slots/compoundVariants/compoundSlots/defaultVariants).

**Regression test**: new `apps/test-tailwind-variants/` asserts all 33 tv() classes survive obfuscation. `scripts/verify-obfuscation.mjs` picks it up automatically (19 apps now).

Closes #61.