### PR TITLE
test: performance regression baseline (release-safety #6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "verify:obfuscation": "node scripts/verify-obfuscation.mjs",
     "test:snapshots": "node scripts/snapshot-app-mappings.mjs",
     "test:snapshots:update": "node scripts/snapshot-app-mappings.mjs --update",
+    "test:perf": "node scripts/check-bench-regression.mjs",
+    "test:perf:update": "node scripts/check-bench-regression.mjs --update",
     "verify:release": "pnpm lint && pnpm format:check && pnpm --filter tailwindcss-obfuscator typecheck && pnpm --filter tailwindcss-obfuscator test && pnpm audit --audit-level=high && pnpm --filter tailwindcss-obfuscator build && node scripts/verify-obfuscation.mjs && pnpm test:snapshots && bash .github/scripts/test-tarball.sh",
     "changeset": "changeset",
     "version-packages": "changeset version",

--- a/packages/tailwindcss-obfuscator/tests/bench/baseline.json
+++ b/packages/tailwindcss-obfuscator/tests/bench/baseline.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Performance baseline for the 5 vitest bench cases. Compared against fresh runs by scripts/check-bench-regression.mjs as a release-safety gate. Any benchmark whose ops/sec (hz) drops below baseline by more than `regressionThresholdPct` (default 25%) fails the build, forcing the maintainer to consciously update this baseline (or revert the perf-degrading commit).",
+  "lastUpdated": "2026-04-30",
+  "lastUpdatedFor": "v2.1.0",
+  "regressionThresholdPct": 25,
+  "_note_about_noise": "CI runners have variable performance. The 25% threshold absorbs the typical run-to-run noise (we observed ±5-10% on macOS GitHub runners) while still catching real regressions like a O(n) → O(n²) algorithm switch. Tighten the threshold (e.g. to 15%) once we have CI-pinned hardware.",
+  "_note_about_units": "Higher hz is better (more ops/sec). Baseline numbers were captured on Apple M-series macOS Darwin 25.4 — re-capture after major Node bumps or runner OS changes.",
+  "benchmarks": {
+    "extractFromJsx (80 cards)": { "hz": 659.1, "unit": "ops/sec" },
+    "extractFromCss (200 rules)": { "hz": 4137.17, "unit": "ops/sec" },
+    "isTailwindClass (1k tokens)": { "hz": 116.68, "unit": "ops/sec" },
+    "transformCss (200 rules)": { "hz": 6313.05, "unit": "ops/sec" },
+    "transformJsxAst (80 cards)": { "hz": 147.13, "unit": "ops/sec" }
+  }
+}

--- a/scripts/check-bench-regression.mjs
+++ b/scripts/check-bench-regression.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+/**
+ * Performance regression gate (release-safety #6).
+ *
+ * Runs the vitest benches via a child process, parses the textual ops/sec
+ * (hz) per benchmark from the output, then compares each against the
+ * committed baseline at packages/tailwindcss-obfuscator/tests/bench/baseline.json.
+ *
+ * Fails (exit 1) if any benchmark drops below baseline by more than
+ * `regressionThresholdPct` (currently 25%) — forcing the maintainer to
+ * either revert the perf-degrading commit or consciously update the
+ * baseline in the same PR (which logs the new floor in git history).
+ *
+ * Usage
+ * ─────
+ * - Verify mode (default, used in CI):
+ *     node scripts/check-bench-regression.mjs
+ *
+ * - Update mode (after a deliberate perf change, eg. an algorithm rewrite):
+ *     node scripts/check-bench-regression.mjs --update
+ *
+ * Why textual parsing
+ * ───────────────────
+ * vitest's --reporter=json emits an empty payload for `bench` (only test
+ * counts, no benchmark data — confirmed against vitest 4.1.5). The
+ * textual output is the only stable, parseable surface today. The
+ * parser below extracts `name` + `hz` from lines like:
+ *     · extractFromJsx (80 cards)      659.10  1.3708 ...
+ * If this format changes upstream, the script will fail to parse and
+ * the test will warn loudly.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const PACKAGE_DIR = path.join(REPO_ROOT, "packages", "tailwindcss-obfuscator");
+const BASELINE_PATH = path.join(PACKAGE_DIR, "tests", "bench", "baseline.json");
+
+const args = new Set(process.argv.slice(2));
+const UPDATE = args.has("--update") || args.has("-u");
+
+const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, "utf8"));
+const THRESHOLD_PCT = baseline.regressionThresholdPct ?? 25;
+
+console.log("");
+console.log("Performance regression gate");
+console.log("baseline:", path.relative(REPO_ROOT, BASELINE_PATH));
+console.log("threshold:", `${THRESHOLD_PCT}% drop = fail`);
+console.log("─".repeat(80));
+
+console.log("Running vitest bench…");
+let stdout;
+try {
+  stdout = execSync("pnpm exec vitest bench --run", {
+    cwd: PACKAGE_DIR,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "inherit"],
+    env: { ...process.env, FORCE_COLOR: "0" },
+  });
+} catch (e) {
+  console.error("❌ vitest bench failed to run:", e.message);
+  process.exit(1);
+}
+
+// Parse lines like:
+//   · extractFromJsx (80 cards)      659.10  1.3708  3.9290  1.5172 ...
+const benchLineRe = /^\s*·\s*(.+?)\s+([\d,]+(?:\.\d+)?)\s+\d/gm;
+const observed = {};
+let m;
+while ((m = benchLineRe.exec(stdout)) !== null) {
+  const name = m[1].trim();
+  const hz = parseFloat(m[2].replace(/,/g, ""));
+  observed[name] = hz;
+}
+
+if (Object.keys(observed).length === 0) {
+  console.error(
+    "❌ Could not parse any benchmark lines from `vitest bench` output. The textual format may have changed."
+  );
+  console.error("Captured stdout (first 1KB):");
+  console.error(stdout.slice(0, 1024));
+  process.exit(1);
+}
+
+console.log("");
+console.log(
+  `${"benchmark".padEnd(38)} ${"baseline hz".padStart(13)} ${"observed hz".padStart(13)} ${"delta".padStart(8)} status`
+);
+console.log("─".repeat(80));
+
+let regressed = 0;
+let updated = 0;
+let unchanged = 0;
+const newBaseline = JSON.parse(JSON.stringify(baseline));
+
+for (const [name, expectedEntry] of Object.entries(baseline.benchmarks)) {
+  const expectedHz = expectedEntry.hz;
+  const observedHz = observed[name];
+  if (observedHz === undefined) {
+    console.error(`${name.padEnd(38)} ${"—".padStart(13)} ${"—".padStart(13)} MISSING from output`);
+    regressed++;
+    continue;
+  }
+  const deltaPct = ((observedHz - expectedHz) / expectedHz) * 100;
+  const deltaStr = `${deltaPct >= 0 ? "+" : ""}${deltaPct.toFixed(1)}%`;
+  let status;
+  if (deltaPct < -THRESHOLD_PCT) {
+    status = `❌ DROP > ${THRESHOLD_PCT}%`;
+    regressed++;
+  } else if (deltaPct > THRESHOLD_PCT) {
+    status = `🚀 +${THRESHOLD_PCT}%+ faster`;
+    if (UPDATE) {
+      newBaseline.benchmarks[name].hz = observedHz;
+      updated++;
+    } else {
+      unchanged++;
+    }
+  } else {
+    status = "✅ within ±" + THRESHOLD_PCT + "%";
+    unchanged++;
+    if (UPDATE) {
+      newBaseline.benchmarks[name].hz = observedHz;
+      updated++;
+    }
+  }
+  console.log(
+    `${name.padEnd(38)} ${String(expectedHz).padStart(13)} ${observedHz.toFixed(2).padStart(13)} ${deltaStr.padStart(8)} ${status}`
+  );
+}
+
+console.log("─".repeat(80));
+
+if (UPDATE) {
+  newBaseline.lastUpdated = new Date().toISOString().slice(0, 10);
+  fs.writeFileSync(BASELINE_PATH, JSON.stringify(newBaseline, null, 2) + "\n", "utf8");
+  console.log(`✏️  baseline updated (${updated} benchmarks).`);
+  process.exit(0);
+}
+
+if (regressed > 0) {
+  console.error("");
+  console.error(`❌ ${regressed} benchmark(s) regressed > ${THRESHOLD_PCT}% vs baseline.`);
+  console.error(
+    "If the regression is intentional (eg. correctness fix that costs perf), update the baseline:"
+  );
+  console.error(
+    "  node scripts/check-bench-regression.mjs --update && git add packages/tailwindcss-obfuscator/tests/bench/baseline.json"
+  );
+  process.exit(1);
+}
+
+console.log(`✅ ${unchanged} benchmark(s) within ±${THRESHOLD_PCT}% of baseline.`);


### PR DESCRIPTION
Adds the 6th release-safety layer : block any PR that regresses one of the 5 vitest benchmarks (extractFromJsx, extractFromCss, isTailwindClass, transformCss, transformJsxAst) by more than 25% vs the committed baseline at `packages/tailwindcss-obfuscator/tests/bench/baseline.json`.

Initial baseline captured for v2.1.0 (Apple M-series macOS). 25% threshold absorbs the typical ±5-10% noise on GitHub runners while still catching algorithmic regressions like an O(n) → O(n²) backtracking switch.

`pnpm test:perf` runs the gate ; `pnpm test:perf:update` re-captures the baseline after a deliberate perf change. Verified locally — all 5 benches within ±10% of baseline.