### PR TITLE
test(coverage): add core-modules coverage floor

### DIFF
--- a/packages/tailwindcss-obfuscator/vitest.config.ts
+++ b/packages/tailwindcss-obfuscator/vitest.config.ts
@@ -18,8 +18,11 @@ export default defineConfig({
       // (PR #67) — excluding them avoids a misleading 0% in the unit
       // coverage report.
       exclude: ["src/**/*.d.ts", "src/cli/**", "src/plugins/**"],
-      // Coverage floor for the core surface (release-safety v2,
-      // 2026-04-30). Baselined at +/- 5 pts below the measured baseline
+      // Coverage floor for the unit-tested surface (release-safety v2,
+      // 2026-04-30). The numerator is "src/**/*.ts minus src/cli/** and
+      // src/plugins/**" — i.e. everything in src/core, src/extractors,
+      // src/transformers, src/utils, plus the root barrels (index.ts,
+      // internals.ts). Baselined at -5 pts below the measured baseline
       // (Stmt 74.95 / Br 65.65 / Func 70.05 / Lines 76.89) so this gate
       // catches regressions of more than ~5 points without being a
       // tripwire on the next normal change. Bump the thresholds upward

--- a/packages/tailwindcss-obfuscator/vitest.config.ts
+++ b/packages/tailwindcss-obfuscator/vitest.config.ts
@@ -18,6 +18,18 @@ export default defineConfig({
       // (PR #67) — excluding them avoids a misleading 0% in the unit
       // coverage report.
       exclude: ["src/**/*.d.ts", "src/cli/**", "src/plugins/**"],
+      // Coverage floor for the core surface (release-safety v2,
+      // 2026-04-30). Baselined at +/- 5 pts below the measured baseline
+      // (Stmt 74.95 / Br 65.65 / Func 70.05 / Lines 76.89) so this gate
+      // catches regressions of more than ~5 points without being a
+      // tripwire on the next normal change. Bump the thresholds upward
+      // as actual coverage climbs ; never lower them silently.
+      thresholds: {
+        statements: 70,
+        branches: 60,
+        functions: 65,
+        lines: 72,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Adds `coverage.thresholds` to `vitest.config.ts` so unit-test coverage on the **core surface** (`src/core/**`, `src/extractors/**`, `src/transformers/**`, `src/utils/**`) cannot regress more than ~5 points before CI fails.

Baseline measured today (2026-04-30) :

| Metric     | Baseline | Floor |
|------------|----------|-------|
| Statements | 74.95 %  | 70    |
| Branches   | 65.65 %  | 60    |
| Functions  | 70.05 %  | 65    |
| Lines      | 76.89 %  | 72    |

\`src/cli/**\` and \`src/plugins/**\` stay excluded from the unit-coverage numerator — they are exercised end-to-end by \`scripts/verify-obfuscation.mjs\` + \`.github/scripts/test-tarball.sh\`, so a unit-coverage 0 % on those folders would be a false signal.

## Why

Part of the \"release-safety v2\" hardening pass. Coverage was being uploaded to Codecov as a signal but no minimum was enforced — so a refactor could silently delete tested branches without anyone noticing until production. The floor is intentionally generous (~5 pts below baseline) so it does not break the next normal PR ; it should be raised over time as actual coverage climbs.

## Test plan

- [x] \`pnpm test:coverage\` passes locally with the new thresholds
- [x] Coverage numbers shown above match the post-change run
- [ ] CI green (lint, typecheck, test matrix, build, audit, tarball smoke, CodeQL, dep-review)