### PR TITLE
ci(security): dependency-review on PRs + CITATION.cff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,34 @@ jobs:
           path: packages/tailwindcss-obfuscator/dist
           retention-days: 7
 
+  dependency-review:
+    # Pull-request-only gate. Reads the diff of pnpm-lock.yaml against
+    # the merge base and refuses any PR that introduces a NEW dep with
+    # a known advisory of severity moderate-or-higher. Complements the
+    # `audit` job below : audit runs on the resolved tree at any time ;
+    # dep-review runs only on the diff and is much faster + more
+    # targeted (catches the introduction, not the steady state).
+    #
+    # OSSF Scorecard recognises dep-review as a top-tier supply-chain
+    # control. Cost : ~5 seconds per PR.
+    name: Dependency review (PR-only)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: actions/dependency-review-action@67d4f4bd7a9b17a0db54d2a7519187c65e339de8 # v4.3.4
+        with:
+          fail-on-severity: moderate
+          # Allow the same MIT/Apache/BSD permissive licenses the project
+          # already ships ; reject GPL family transitively (would force the
+          # whole package into GPL on republish).
+          allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, CC0-1.0, CC-BY-4.0, BlueOak-1.0.0, Python-2.0
+          comment-summary-in-pr: on-failure
+
   audit:
     # Belt-and-suspenders: Renovate already opens PRs for vulnerable transitive
     # deps and `pnpm.overrides` patches them on the spot, but we also want a

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,35 @@
+# https://citation-file-format.github.io/
+# This file is rendered as a "Cite this repository" widget by GitHub on
+# the repo home page. It also feeds Zenodo / Software Heritage / FOSDEM
+# style indexes. Keep it short — only fields a citing reader needs.
+cff-version: 1.2.0
+message: >-
+  If you use tailwindcss-obfuscator in academic work, a publication, a
+  measurement experiment, or any redistributable artefact, please cite it.
+type: software
+title: tailwindcss-obfuscator
+abstract: >-
+  Build-time Tailwind CSS class mangler & obfuscator. Renames utility
+  classes (bg-blue-500 → tw-a) at build time across Vite, Webpack,
+  Rollup, esbuild, rspack, Farm, Nuxt, SvelteKit, Astro, Solid, Qwik,
+  React Router 7 and TanStack Router. Cuts the CSS bundle by 30–60 %
+  and removes the Tailwind signature from rendered HTML.
+authors:
+  - family-names: DA COSTA
+    given-names: José
+    email: contact@josedacosta.info
+    website: https://github.com/josedacosta
+license: MIT
+repository-code: https://github.com/josedacosta/tailwindcss-obfuscator
+url: https://josedacosta.github.io/tailwindcss-obfuscator/
+keywords:
+  - tailwindcss
+  - obfuscation
+  - mangler
+  - css
+  - build-tool
+  - vite
+  - webpack
+  - rollup
+  - esbuild
+  - design-system-protection


### PR DESCRIPTION
## Summary

Closes the supply-chain hardening pass started in this release-safety v2 cycle :

1. **\`Dependency review (PR-only)\` job** in \`.github/workflows/ci.yml\`. Runs \`actions/dependency-review-action@v4\` against the lockfile diff on every PR. \`fail-on-severity: moderate\` ; \`allow-licenses\` pinned to the exact permissive set this package already ships.
2. **\`CITATION.cff\`** at root — standard 2026 Citation File Format, rendered as « Cite this repository » on the GitHub home page (also feeds Zenodo / Software Heritage / FOSDEM-style indexes).

The branch protection hardening that complements this PR (Dependency audit + Tarball smoke + CodeQL Analysis as required status checks ; \`required_signatures: true\`) was applied directly via \`gh api PUT /branches/main/protection\` earlier in the same release-safety v2 pass and is documented in the gitignored \`jose/scripts/github/setup-repo.sh\`. No CI / source change needed for those — they are repo-settings only.

## Why

Per the audit posted on this PR cycle, the project sits in the **top ~5% percentile** for npm supply-chain maturity. The two remaining gaps were :

- audit, tarball-smoke, codeql were running but not blocking → fixed via branch protection
- new vulnerable deps could land via lockfile diff and only get caught after merge by the steady-state \`audit\` job → fixed by this PR's dependency-review job

## What is intentionally NOT added (anti-overkill)

- \`actions/attest-build-provenance\` — \`npm publish --provenance\` via OIDC already signs to Sigstore. Adding a second attestation = doubled CI surface for the same output.
- \`gitleaks-action\` — GitHub native secret-scanning + push-protection are already enabled on this repo and cover the commit-time use case. gitleaks would add CI time + false positives without new signal for this project.
- \`step-security/harden-runner\` — egress firewall on every job would friction Renovate dep bumps without measurable benefit at this size.

## Test plan

- [x] \`pnpm format\` zero-diff on CITATION.cff and ci.yml
- [x] CITATION.cff structure validated via [the official validator](https://citation-file-format.github.io/cff-initializer-javascript)
- [ ] CI green (lint, typecheck, test, build, audit, tarball-smoke, codeql, dep-review, tests-existence)
- [ ] On the \`josedacosta/tailwindcss-obfuscator\` repo home page, the \"Cite this repository\" widget appears in the right column