### PR TITLE
docs(limitations): drop reference to gitignored agent brief

### DIFF
--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -245,4 +245,4 @@ import { cn } from "@/lib/utils";
 
 ## How to keep this page honest
 
-Whenever a `❌` / `⚠️` / "Not supported" / "Partial" lands in the documentation, the agent rule in [`CLAUDE.md`](https://github.com/josedacosta/tailwindcss-obfuscator/blob/main/CLAUDE.md) requires it to be paired with a card on this page (or a one-line link to the existing card). If you find a bare `❌` anywhere on the docs site without a card or link explaining it, please [open a doc bug](https://github.com/josedacosta/tailwindcss-obfuscator/issues/new/choose) — that's a violation of the project's documentation rule.
+Whenever a `❌` / `⚠️` / "Not supported" / "Partial" lands in the documentation, the project's documentation rule requires it to be paired with a card on this page (or a one-line link to the existing card). If you find a bare `❌` anywhere on the docs site without a card or link explaining it, please [open a doc bug](https://github.com/josedacosta/tailwindcss-obfuscator/issues/new/choose).


### PR DESCRIPTION
## Summary

The « How to keep this page honest » footer linked to `CLAUDE.md`, which is gitignored. The link `github.com/.../blob/main/CLAUDE.md` therefore 404s, and the file is irrelevant to public readers anyway. Restate the policy in the page's own voice.

This pairs with a new ULTRA-IMPORTANT rule in the agent brief : public-facing docs (`README.md`, `docs/**`) must never reference `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` (those are gitignored agent briefs, not part of the public project).

## Test plan

- [x] `pnpm docs:build` succeeds
- [ ] CI green
