### PR TITLE
docs: refresh stale version refs + drop trio ref from test comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@
 <br />
 
 <!-- Badges row 1 — package -->
-<!-- Downloads badge intentionally omitted while npm aggregates stats for the fresh v2.0.0
-     publish (~24-48h). Re-add `npm/dm` here once https://api.npmjs.org/downloads returns
+<!-- Downloads badge intentionally omitted while npm download stats stabilise after the
+     fresh-publish window. Re-add `npm/dm` here once https://api.npmjs.org/downloads returns
      non-zero. Until then, the install-command badge below carries the same call-to-action. -->
 <p>
   <a href="https://www.npmjs.com/package/tailwindcss-obfuscator">
@@ -593,7 +593,7 @@ pnpm install
 # 2. Build the main package
 pnpm --filter tailwindcss-obfuscator build
 
-# 3. Run the test suite (395 tests at v2.0.1, growing)
+# 3. Run the test suite (418 tests as of v2.1.0, growing)
 pnpm --filter tailwindcss-obfuscator test
 ```
 

--- a/packages/tailwindcss-obfuscator/tests/public-api-types.test.ts
+++ b/packages/tailwindcss-obfuscator/tests/public-api-types.test.ts
@@ -13,9 +13,11 @@
  * blocks the merge.
  *
  * To intentionally change the public API :
- * 1. Bump the changeset to **major** (per the SemVer rules in CLAUDE.md).
+ * 1. Add a changeset bumping the package to **major** (the standard SemVer
+ *    contract for a breaking signature change).
  * 2. Update the assertions below to match the new shape.
- * 3. Document the breaking change in the changeset summary.
+ * 3. Document the breaking change in the changeset summary so the
+ *    CHANGELOG entry tells consumers what to migrate.
  *
  * Plugin sub-paths (`./vite`, `./webpack`, …) have their own integration
  * coverage via the tarball smoke test (PR #67) and per-export validators


### PR DESCRIPTION
## Summary

Three pre-release doc-review findings :

1. `README.md` downloads-badge comment referenced the `v2.0.0` publish window (we are on v2.1.0). Refreshed.
2. `README.md` mentioned « 395 tests at v2.0.1, growing ». Updated to « 418 tests as of v2.1.0, growing ».
3. `packages/tailwindcss-obfuscator/tests/public-api-types.test.ts` comment pointed at the gitignored agent brief. Restated the SemVer guidance in its own voice.

## Test plan

- [x] `pnpm verify:release` green
- [ ] CI green
