### PR TITLE
chore(release): backfill changesets for #89 commander + #93 unplugin

### DIFF
--- a/.changeset/commander-v14.md
+++ b/.changeset/commander-v14.md
@@ -1,0 +1,5 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Bump `commander` from v12 to v14 (internal CLI parsing dependency, landed in #89). The CLI surface (`tw-obfuscator --help`, `tw-obfuscator run`, flags) is unchanged ; the bump is covered by the tarball-smoke gate that runs `tw-obfuscator --version` after `npm install` of the freshly-packed tarball. Note : commander 14 requires Node.js v20+ which is already the package's documented minimum.

--- a/.changeset/unplugin-v3.md
+++ b/.changeset/unplugin-v3.md
@@ -1,0 +1,5 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Bump the internal `unplugin` core from v2 to v3 (landed in #93). The package's public API surface is unchanged ; all 10 plugin entries (`./vite`, `./webpack`, `./rollup`, `./esbuild`, `./rspack`, `./farm`, `./nuxt`, `./cli`, `./internals`, root) continue to resolve and import cleanly via both ESM and CJS — verified end-to-end by the tarball-smoke gate. Internal-only refresh.


### PR DESCRIPTION
Backfills the two patch changesets that were dropped at squash-merge time when Renovate force-pushed over my changeset commit on PRs #89 and #93.