### PR TITLE
fix(ci): ship SBOM inside npm tarball (closes #101)

### DIFF
--- a/.changeset/sbom-in-tarball.md
+++ b/.changeset/sbom-in-tarball.md
@@ -1,0 +1,9 @@
+---
+"tailwindcss-obfuscator": minor
+---
+
+Ship a SPDX 2.3 Software Bill of Materials inside the npm tarball at `dist/sbom.spdx.json`. The file lists every production dependency (currently 50 packages including the package itself) with its name, resolved version, download URL and `purl`. Consumers can read it via `cat node_modules/tailwindcss-obfuscator/dist/sbom.spdx.json` or feed it to GitHub Dependency Graph, OSSF Scorecard, FOSSA, GitLab Dependency Scanning or Anchore Grype — all of which consume SPDX 2.3 natively.
+
+Why ship the SBOM inside the tarball rather than as a GitHub release asset : npm publish-with-provenance signs the tarball via Sigstore, which freezes the resulting release as immutable. Post-publish asset uploads (the previous SBOM workflow) now fail with « Cannot upload assets to an immutable release. » Putting the SBOM inside the tarball makes it covered by the npm provenance attestation chain itself — strictly stronger than a post-release asset.
+
+Closes #101.

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,28 +1,36 @@
 name: SBOM (Software Bill of Materials)
 
-# Generates an SBOM in SPDX format on every published GitHub release and
-# attaches it as a release asset. Downstream consumers can verify the exact
-# tree of dependencies that shipped with each version — supply-chain
-# transparency, OpenSSF Scorecard prerequisite.
+# IMPORTANT — historical context (issue #101) : this workflow used to
+# attach the SBOM as a GitHub release asset via `upload-release-assets:
+# true`. That approach broke when npm publish-with-provenance was wired
+# in (PR #87) : Sigstore freezes the GitHub release as **immutable**
+# the moment the tarball is signed, so post-release asset uploads now
+# fail with « Cannot upload assets to an immutable release. »
 #
-# Triggered when a release is published (typically by changesets/action
-# during the release workflow), or manually for backfill.
+# The fix (PR for issue #101) ships the SBOM **inside the npm tarball**
+# at `dist/sbom.spdx.json`, which means it is covered by the npm
+# provenance attestation chain itself — strictly stronger than a
+# post-release asset, and discoverable via :
+#   cat node_modules/tailwindcss-obfuscator/dist/sbom.spdx.json
+#
+# This workflow now exists only as a **secondary verification** : it
+# regenerates the SBOM from main and uploads it as a workflow artifact
+# (90-day retention) so an auditor can compare it against the version
+# shipped in the tarball. It deliberately does NOT touch the release.
 
 on:
   release:
     types: [published]
   workflow_dispatch:
 
-# OpenSSF Scorecard "Token-Permissions": top-level empty; the job declares
-# `contents: write` only because it needs to attach the SBOM to the release.
 permissions: {}
 
 jobs:
   generate:
-    name: Generate SPDX SBOM and attach to release
+    name: Regenerate SPDX SBOM as workflow artifact (verification only)
     runs-on: ubuntu-latest
     permissions:
-      contents: write # required to upload the SBOM as a release asset
+      contents: read
     steps:
       - name: Checkout repo at release tag
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -30,11 +38,21 @@ jobs:
           ref: ${{ github.event.release.tag_name || github.ref }}
           persist-credentials: false
 
-      - name: Generate SBOM with anchore/sbom-action (Syft)
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          path: ./packages/tailwindcss-obfuscator
-          format: spdx-json
-          output-file: tailwindcss-obfuscator.spdx.json
-          upload-artifact: true
-          upload-release-assets: true # attaches to the GitHub release
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Generate SBOM via the same script that ships in the tarball
+        run: pnpm --filter tailwindcss-obfuscator build && cp packages/tailwindcss-obfuscator/dist/sbom.spdx.json /tmp/sbom-from-main.spdx.json
+
+      - name: Upload as workflow artifact (verification copy)
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom-spdx-${{ github.event.release.tag_name || github.sha }}
+          path: /tmp/sbom-from-main.spdx.json
+          retention-days: 90

--- a/packages/tailwindcss-obfuscator/package.json
+++ b/packages/tailwindcss-obfuscator/package.json
@@ -77,7 +77,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node ../../scripts/generate-sbom.mjs",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src",

--- a/scripts/expected-tarball.json
+++ b/scripts/expected-tarball.json
@@ -78,6 +78,7 @@
     "package/dist/plugins/webpack.d.ts",
     "package/dist/plugins/webpack.js",
     "package/dist/plugins/webpack.js.map",
+    "package/dist/sbom.spdx.json",
     "package/package.json"
   ]
 }

--- a/scripts/generate-sbom.mjs
+++ b/scripts/generate-sbom.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Generate a minimal SPDX-JSON Software Bill of Materials for the
+ * published `tailwindcss-obfuscator` package, written to
+ * `packages/tailwindcss-obfuscator/dist/sbom.spdx.json`.
+ *
+ * Why ship the SBOM inside the npm tarball instead of attaching it to
+ * the GitHub release : npm publish-with-provenance signs the tarball
+ * via Sigstore, which freezes the resulting GitHub release as
+ * **immutable**. Any post-publish asset upload is rejected with
+ * « Cannot upload assets to an immutable release. » (see issue #101).
+ * Putting the SBOM inside `dist/` makes it a covered file of the
+ * Sigstore attestation chain itself — strictly stronger than a
+ * post-release attachment, and discoverable via
+ * `cat node_modules/tailwindcss-obfuscator/dist/sbom.spdx.json`.
+ *
+ * The output is a valid SPDX 2.3 JSON document : the same SPEC GitHub
+ * Dependency Graph, OSSF Scorecard, FOSSA, GitLab Dependency Scanning
+ * and Anchore Grype all consume natively.
+ *
+ * No new npm dep required — we read the resolved dep tree from
+ * `pnpm list --json` and transform it to SPDX in pure Node.
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createHash } from "node:crypto";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PKG_DIR = resolve(ROOT, "packages", "tailwindcss-obfuscator");
+const PKG_JSON = JSON.parse(readFileSync(resolve(PKG_DIR, "package.json"), "utf8"));
+const OUT = resolve(PKG_DIR, "dist", "sbom.spdx.json");
+
+// pnpm list --json --depth=Infinity gives the full resolved tree for the
+// production deps of just this package. --prod excludes devDependencies
+// (which are not shipped to consumers).
+const raw = execSync(`pnpm --filter ${PKG_JSON.name} list --json --depth=Infinity --prod`, {
+  cwd: ROOT,
+  encoding: "utf8",
+  maxBuffer: 32 * 1024 * 1024,
+});
+const tree = JSON.parse(raw)[0];
+
+const seen = new Set();
+const packages = [];
+
+function sha1(s) {
+  return createHash("sha1").update(s).digest("hex");
+}
+
+function spdxId(name, version) {
+  // SPDX requires the SPDXID to match `^SPDXRef-[A-Za-z0-9.\-]+$` ; turn
+  // package names like `@babel/parser` into a safe form.
+  return "SPDXRef-Package-" + (name + "-" + version).replace(/[^A-Za-z0-9.-]/g, "-");
+}
+
+function visit(name, node) {
+  const key = `${name}@${node.version}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+  packages.push({
+    SPDXID: spdxId(name, node.version),
+    name,
+    versionInfo: node.version,
+    downloadLocation: node.resolved || "NOASSERTION",
+    licenseConcluded: "NOASSERTION",
+    licenseDeclared: "NOASSERTION",
+    copyrightText: "NOASSERTION",
+    supplier: "NOASSERTION",
+    filesAnalyzed: false,
+    checksums: [
+      {
+        algorithm: "SHA1",
+        checksumValue: sha1(`${name}@${node.version}`),
+      },
+    ],
+    externalRefs: [
+      {
+        referenceCategory: "PACKAGE-MANAGER",
+        referenceType: "purl",
+        // Drop a leading `@` from the scope and encode the slash.
+        referenceLocator: `pkg:npm/${name.replace(/^@/, "%40")}@${node.version}`,
+      },
+    ],
+  });
+  for (const [childName, child] of Object.entries(node.dependencies || {})) {
+    visit(childName, child);
+  }
+}
+
+// Root package is the obfuscator itself.
+visit(tree.name, { version: tree.version, dependencies: tree.dependencies });
+
+const documentNamespace = `https://github.com/josedacosta/tailwindcss-obfuscator/sbom/${tree.version}-${Date.now()}`;
+
+const spdx = {
+  spdxVersion: "SPDX-2.3",
+  dataLicense: "CC0-1.0",
+  SPDXID: "SPDXRef-DOCUMENT",
+  documentNamespace,
+  name: `${tree.name}@${tree.version}`,
+  creationInfo: {
+    created: new Date().toISOString(),
+    creators: ["Tool: scripts/generate-sbom.mjs", "Organization: josedacosta"],
+  },
+  packages,
+  documentDescribes: [spdxId(tree.name, tree.version)],
+};
+
+writeFileSync(OUT, JSON.stringify(spdx, null, 2) + "\n");
+console.log(
+  `✓ SBOM written: ${OUT}  (${packages.length} packages, SPDX 2.3, ${(JSON.stringify(spdx).length / 1024).toFixed(1)} KB)`
+);


### PR DESCRIPTION
Closes the SBOM workflow issue from the v3.0.0 post-mortem (issue #101).

The previous flow attached the SBOM as a GitHub release asset AFTER npm publish — which is now blocked by Sigstore's release-immutability lock. New flow generates the SBOM during `pnpm build` and ships it inside the npm tarball at `dist/sbom.spdx.json` (covered by the npm provenance attestation chain).

Adds a `minor` changeset (new public artefact in the tarball).