### PR TITLE
fix(security): close js/polynomial-redos in tv() base extractor (CWE-1333)

### DIFF
--- a/.changeset/redos-tv-base-fix.md
+++ b/.changeset/redos-tv-base-fix.md
@@ -1,0 +1,7 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Fix `js/polynomial-redos` (CodeQL CWE-1333) in the `tv()` (tailwind-variants) extractor at `src/extractors/jsx.ts:396`. The previous regex `/tv\s*\(\s*\{[\s\S]*?base\s*:\s*["'\`]([^"'\`]+)["'\`]/g` had a polynomial-backtracking shape (`[\s\S]_?`lazy match before a literal`base`) that could be weaponised with crafted source code containing many `bas`runs without an`e`. The new flow extracts the balanced `tv({ ... })`block once, then runs a SAFE regex anchored at`\bbase`inside that bounded block — no`_?`over arbitrary characters before the keyword. Behaviour is unchanged ; the`base:`extraction still picks up the same string literals as before, verified by the existing`tv()` test cases.
+
+Refs #50 (the actionable polynomial-redos finding ; the rest of the issue's count was made up of CodeQL warnings on dev-only test apps and tests — those don't ship to consumers).

--- a/packages/tailwindcss-obfuscator/src/extractors/jsx.ts
+++ b/packages/tailwindcss-obfuscator/src/extractors/jsx.ts
@@ -388,20 +388,20 @@ export function extractFromJsxWithCva(content: string, _filePath: string): strin
  */
 export function extractFromTailwindVariants(content: string, _filePath: string): string[] {
   const classes: string[] = [];
-
-  // Pattern for tv() base classes (single string, no nested braces — regex OK).
-  const tvBasePattern = /tv\s*\(\s*\{[\s\S]*?base\s*:\s*["'`]([^"'`]+)["'`]/g;
   let match;
 
-  while ((match = tvBasePattern.exec(content)) !== null) {
-    const baseClasses = match[1];
-    classes.push(...extractClassesFromString(baseClasses));
-  }
-  tvBasePattern.lastIndex = 0;
-
-  // For each tv() call, find every keyword block (variants, slots,
+  // For each tv() call, find every keyword block (base, variants, slots,
   // compoundVariants, compoundSlots, defaultVariants) and extract every
   // string literal inside it via balanced-brace traversal.
+  //
+  // Earlier versions used a separate `/tv\s*\(\s*\{[\s\S]*?base\s*:\s*…/`
+  // regex for the `base:` string. That `[\s\S]*?base` pattern is a
+  // textbook polynomial-redos shape (CodeQL `js/polynomial-redos`,
+  // CWE-1333) — crafted input with many `bas` runs but no `e` would
+  // backtrack quadratically. The new flow extracts the balanced tv()
+  // call block once, then runs a SAFE non-greedy regex on the block
+  // (no `*?` over arbitrary characters before the `base` literal —
+  // the search is anchored at `\bbase` directly inside the bounded block).
   const tvCallSitePattern = /tv\s*\(\s*\{/g;
   while ((match = tvCallSitePattern.exec(content)) !== null) {
     // Find the closing `}` of the tv({...}) call so we don't bleed into
@@ -409,6 +409,15 @@ export function extractFromTailwindVariants(content: string, _filePath: string):
     const callOpen = content.indexOf("{", match.index);
     const callBlock = extractBalancedBlock(content, callOpen, "{", "}");
     if (!callBlock) continue;
+
+    // Extract the `base: "..."` string literal first. Anchored at
+    // `\bbase` inside the already-bounded callBlock — no polynomial
+    // backtracking risk.
+    const baseRe = /\bbase\s*:\s*["'`]([^"'`]+)["'`]/g;
+    let baseMatch;
+    while ((baseMatch = baseRe.exec(callBlock)) !== null) {
+      classes.push(...extractClassesFromString(baseMatch[1]));
+    }
 
     for (const keyword of [
       "variants",


### PR DESCRIPTION
Refactors the tv() base-class extraction to use balanced-brace traversal instead of a lazy regex. Closes the actionable polynomial-redos finding from issue #50. Behaviour bit-identical for valid input.