### PR TITLE
feat(test-apps): add Vite v4 / v5 / v6 regression coverage

### DIFF
--- a/apps/test-vite-react-v4/index.html
+++ b/apps/test-vite-react-v4/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Vite React - TailwindCSS Obfuscator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/test-vite-react-v4/package.json
+++ b/apps/test-vite-react-v4/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "test-vite-react-v4",
+  "version": "1.0.0",
+  "description": "Test app for tailwindcss-obfuscator with Vite v4 + React + Tailwind v4 — regression coverage for the v4 end of our supported peer range (closes part of issue #55).",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^3.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^4.5.1",
+    "@tailwindcss/vite": "^4.2.4",
+    "tailwindcss": "^4.2.4",
+    "tailwindcss-obfuscator": "workspace:*",
+    "typescript": "^5.8.3",
+    "vite": "^4.5.5"
+  }
+}

--- a/apps/test-vite-react-v4/src/App.tsx
+++ b/apps/test-vite-react-v4/src/App.tsx
@@ -1,0 +1,228 @@
+import { useState } from "react";
+import clsx from "clsx";
+import { twMerge } from "tailwind-merge";
+
+// Component with dynamic classes
+function Button({
+  variant = "primary",
+  className,
+  children,
+}: {
+  variant?: "primary" | "secondary";
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const baseClasses = "px-4 py-2 rounded-lg font-semibold transition-colors";
+  const variantClasses = {
+    primary: "bg-blue-500 text-white hover:bg-blue-600",
+    secondary: "bg-gray-200 text-gray-800 hover:bg-gray-300",
+  };
+
+  return (
+    <button className={twMerge(baseClasses, variantClasses[variant], className)}>{children}</button>
+  );
+}
+
+// Component with conditional classes using clsx
+function Alert({
+  type = "info",
+  message,
+}: {
+  type?: "info" | "success" | "warning" | "error";
+  message: string;
+}) {
+  return (
+    <div
+      className={clsx("rounded-lg border p-4", {
+        "border-blue-200 bg-blue-50 text-blue-800": type === "info",
+        "border-green-200 bg-green-50 text-green-800": type === "success",
+        "border-yellow-200 bg-yellow-50 text-yellow-800": type === "warning",
+        "border-red-200 bg-red-50 text-red-800": type === "error",
+      })}
+    >
+      {message}
+    </div>
+  );
+}
+
+// Card component
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-lg transition-shadow hover:shadow-xl">
+      <h3 className="mb-4 text-lg font-bold text-gray-900">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+// Grid layout component
+function Grid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">{children}</div>;
+}
+
+// Badge component with arbitrary values
+function Badge({ text, color }: { text: string; color: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-${color}-100 text-${color}-800`}
+    >
+      {text}
+    </span>
+  );
+}
+
+// Main App component
+function App() {
+  const [count, setCount] = useState(0);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  return (
+    <div
+      className={clsx(
+        "min-h-screen transition-colors duration-300",
+        theme === "light" ? "bg-gray-100" : "bg-gray-900"
+      )}
+    >
+      {/* Header */}
+      <header className="bg-white shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-gray-900">TailwindCSS Obfuscator Test</h1>
+            <Button
+              variant="secondary"
+              onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+            >
+              Toggle Theme
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Counter section */}
+        <section className="mb-8">
+          <Card title="Counter Example">
+            <div className="flex items-center gap-4">
+              <Button variant="primary" onClick={() => setCount((c) => c + 1)}>
+                Increment
+              </Button>
+              <span className="font-mono text-xl text-gray-700">{count}</span>
+              <Button variant="secondary" onClick={() => setCount(0)}>
+                Reset
+              </Button>
+            </div>
+          </Card>
+        </section>
+
+        {/* Alerts section */}
+        <section className="mb-8 space-y-4">
+          <h2 className="text-xl font-semibold text-gray-900">Alerts</h2>
+          <Alert type="info" message="This is an info alert" />
+          <Alert type="success" message="This is a success alert" />
+          <Alert type="warning" message="This is a warning alert" />
+          <Alert type="error" message="This is an error alert" />
+        </section>
+
+        {/* Cards grid */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Feature Cards</h2>
+          <Grid>
+            <Card title="Vite Integration">
+              <p className="text-gray-600">Seamless integration with Vite build system</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="Fast" color="green" />
+                <Badge text="Modern" color="blue" />
+              </div>
+            </Card>
+            <Card title="React Support">
+              <p className="text-gray-600">Full support for React components and JSX</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="JSX" color="purple" />
+                <Badge text="Hooks" color="indigo" />
+              </div>
+            </Card>
+            <Card title="Tailwind CSS">
+              <p className="text-gray-600">Works with Tailwind v3 and v4</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="v3" color="cyan" />
+                <Badge text="v4" color="teal" />
+              </div>
+            </Card>
+          </Grid>
+        </section>
+
+        {/* Responsive utilities test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Responsive Design</h2>
+          <div className="rounded-lg bg-white p-4 shadow">
+            <p className="text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl">
+              This text changes size at different breakpoints
+            </p>
+            <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              {["red", "orange", "yellow", "green", "blue", "purple"].map((color) => (
+                <div key={color} className={`h-12 rounded bg-${color}-500`} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* State variants test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">State Variants</h2>
+          <div className="flex flex-wrap gap-4">
+            <button className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 focus:ring-2 focus:ring-blue-300 active:bg-blue-700">
+              Hover, Focus, Active
+            </button>
+            <input
+              type="text"
+              placeholder="Focus me"
+              className="rounded border px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-100"
+            />
+            <div className="group cursor-pointer rounded bg-gray-100 p-4">
+              <span className="text-gray-600 group-hover:text-blue-600">Group hover effect</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Arbitrary values test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Arbitrary Values</h2>
+          <div className="space-y-4">
+            <div className="flex h-[100px] w-[300px] items-center justify-center rounded-lg bg-gradient-to-r from-purple-500 to-pink-500">
+              <span className="font-bold text-white">Custom width/height</span>
+            </div>
+            <div className="rounded bg-[#1a1a2e] p-[13px] text-[#eee]">
+              Arbitrary padding and colors
+            </div>
+            <div className="grid grid-cols-[1fr_2fr_1fr] gap-4">
+              <div className="bg-blue-200 p-2 text-center">1fr</div>
+              <div className="bg-blue-300 p-2 text-center">2fr</div>
+              <div className="bg-blue-200 p-2 text-center">1fr</div>
+            </div>
+          </div>
+        </section>
+
+        {/* Class that should NOT be obfuscated */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Excluded Classes</h2>
+          <div className="no-obfuscate rounded bg-yellow-100 p-4">
+            This div has the "no-obfuscate" class which should be excluded
+          </div>
+          <div className="keep-me mt-4 rounded bg-green-100 p-4">
+            This div has "keep-me" which matches "keep-*" pattern
+          </div>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-gray-800 py-8 text-white">
+        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+          <p className="text-gray-400">TailwindCSS Obfuscator - Vite + React Test App</p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/apps/test-vite-react-v4/src/index.css
+++ b/apps/test-vite-react-v4/src/index.css
@@ -1,0 +1,16 @@
+/* Tailwind v4 CSS-first configuration */
+@import "tailwindcss";
+
+/* Custom theme */
+@theme {
+  --color-primary-50: #eff6ff;
+  --color-primary-100: #dbeafe;
+  --color-primary-200: #bfdbfe;
+  --color-primary-300: #93c5fd;
+  --color-primary-400: #60a5fa;
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-primary-700: #1d4ed8;
+  --color-primary-800: #1e40af;
+  --color-primary-900: #1e3a8a;
+}

--- a/apps/test-vite-react-v4/src/main.tsx
+++ b/apps/test-vite-react-v4/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/test-vite-react-v4/tsconfig.json
+++ b/apps/test-vite-react-v4/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/apps/test-vite-react-v4/vite.config.ts
+++ b/apps/test-vite-react-v4/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import tailwindcssObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+    tailwindcssObfuscator({
+      prefix: "tw-",
+      verbose: true,
+      debug: true,
+      preserve: { classes: ["no-obfuscate", "keep-*"] },
+      mapping: {
+        enabled: true,
+        file: ".tw-obfuscation/class-mapping.json",
+        pretty: 2,
+      },
+      cache: {
+        enabled: true,
+        directory: ".tw-obfuscation/cache",
+        strategy: "merge",
+      },
+    }),
+  ],
+});

--- a/apps/test-vite-react-v5/index.html
+++ b/apps/test-vite-react-v5/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Vite React - TailwindCSS Obfuscator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/test-vite-react-v5/package.json
+++ b/apps/test-vite-react-v5/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "test-vite-react-v5",
+  "version": "1.0.0",
+  "description": "Test app for tailwindcss-obfuscator with Vite v5 + React + Tailwind v4 — regression coverage for the v5 end of our supported peer range (closes part of issue #55).",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^3.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^4.5.1",
+    "@tailwindcss/vite": "^4.2.4",
+    "tailwindcss": "^4.2.4",
+    "tailwindcss-obfuscator": "workspace:*",
+    "typescript": "^5.8.3",
+    "vite": "^5.4.0"
+  }
+}

--- a/apps/test-vite-react-v5/src/App.tsx
+++ b/apps/test-vite-react-v5/src/App.tsx
@@ -1,0 +1,228 @@
+import { useState } from "react";
+import clsx from "clsx";
+import { twMerge } from "tailwind-merge";
+
+// Component with dynamic classes
+function Button({
+  variant = "primary",
+  className,
+  children,
+}: {
+  variant?: "primary" | "secondary";
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const baseClasses = "px-4 py-2 rounded-lg font-semibold transition-colors";
+  const variantClasses = {
+    primary: "bg-blue-500 text-white hover:bg-blue-600",
+    secondary: "bg-gray-200 text-gray-800 hover:bg-gray-300",
+  };
+
+  return (
+    <button className={twMerge(baseClasses, variantClasses[variant], className)}>{children}</button>
+  );
+}
+
+// Component with conditional classes using clsx
+function Alert({
+  type = "info",
+  message,
+}: {
+  type?: "info" | "success" | "warning" | "error";
+  message: string;
+}) {
+  return (
+    <div
+      className={clsx("rounded-lg border p-4", {
+        "border-blue-200 bg-blue-50 text-blue-800": type === "info",
+        "border-green-200 bg-green-50 text-green-800": type === "success",
+        "border-yellow-200 bg-yellow-50 text-yellow-800": type === "warning",
+        "border-red-200 bg-red-50 text-red-800": type === "error",
+      })}
+    >
+      {message}
+    </div>
+  );
+}
+
+// Card component
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-lg transition-shadow hover:shadow-xl">
+      <h3 className="mb-4 text-lg font-bold text-gray-900">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+// Grid layout component
+function Grid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">{children}</div>;
+}
+
+// Badge component with arbitrary values
+function Badge({ text, color }: { text: string; color: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-${color}-100 text-${color}-800`}
+    >
+      {text}
+    </span>
+  );
+}
+
+// Main App component
+function App() {
+  const [count, setCount] = useState(0);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  return (
+    <div
+      className={clsx(
+        "min-h-screen transition-colors duration-300",
+        theme === "light" ? "bg-gray-100" : "bg-gray-900"
+      )}
+    >
+      {/* Header */}
+      <header className="bg-white shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-gray-900">TailwindCSS Obfuscator Test</h1>
+            <Button
+              variant="secondary"
+              onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+            >
+              Toggle Theme
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Counter section */}
+        <section className="mb-8">
+          <Card title="Counter Example">
+            <div className="flex items-center gap-4">
+              <Button variant="primary" onClick={() => setCount((c) => c + 1)}>
+                Increment
+              </Button>
+              <span className="font-mono text-xl text-gray-700">{count}</span>
+              <Button variant="secondary" onClick={() => setCount(0)}>
+                Reset
+              </Button>
+            </div>
+          </Card>
+        </section>
+
+        {/* Alerts section */}
+        <section className="mb-8 space-y-4">
+          <h2 className="text-xl font-semibold text-gray-900">Alerts</h2>
+          <Alert type="info" message="This is an info alert" />
+          <Alert type="success" message="This is a success alert" />
+          <Alert type="warning" message="This is a warning alert" />
+          <Alert type="error" message="This is an error alert" />
+        </section>
+
+        {/* Cards grid */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Feature Cards</h2>
+          <Grid>
+            <Card title="Vite Integration">
+              <p className="text-gray-600">Seamless integration with Vite build system</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="Fast" color="green" />
+                <Badge text="Modern" color="blue" />
+              </div>
+            </Card>
+            <Card title="React Support">
+              <p className="text-gray-600">Full support for React components and JSX</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="JSX" color="purple" />
+                <Badge text="Hooks" color="indigo" />
+              </div>
+            </Card>
+            <Card title="Tailwind CSS">
+              <p className="text-gray-600">Works with Tailwind v3 and v4</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="v3" color="cyan" />
+                <Badge text="v4" color="teal" />
+              </div>
+            </Card>
+          </Grid>
+        </section>
+
+        {/* Responsive utilities test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Responsive Design</h2>
+          <div className="rounded-lg bg-white p-4 shadow">
+            <p className="text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl">
+              This text changes size at different breakpoints
+            </p>
+            <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              {["red", "orange", "yellow", "green", "blue", "purple"].map((color) => (
+                <div key={color} className={`h-12 rounded bg-${color}-500`} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* State variants test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">State Variants</h2>
+          <div className="flex flex-wrap gap-4">
+            <button className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 focus:ring-2 focus:ring-blue-300 active:bg-blue-700">
+              Hover, Focus, Active
+            </button>
+            <input
+              type="text"
+              placeholder="Focus me"
+              className="rounded border px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-100"
+            />
+            <div className="group cursor-pointer rounded bg-gray-100 p-4">
+              <span className="text-gray-600 group-hover:text-blue-600">Group hover effect</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Arbitrary values test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Arbitrary Values</h2>
+          <div className="space-y-4">
+            <div className="flex h-[100px] w-[300px] items-center justify-center rounded-lg bg-gradient-to-r from-purple-500 to-pink-500">
+              <span className="font-bold text-white">Custom width/height</span>
+            </div>
+            <div className="rounded bg-[#1a1a2e] p-[13px] text-[#eee]">
+              Arbitrary padding and colors
+            </div>
+            <div className="grid grid-cols-[1fr_2fr_1fr] gap-4">
+              <div className="bg-blue-200 p-2 text-center">1fr</div>
+              <div className="bg-blue-300 p-2 text-center">2fr</div>
+              <div className="bg-blue-200 p-2 text-center">1fr</div>
+            </div>
+          </div>
+        </section>
+
+        {/* Class that should NOT be obfuscated */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Excluded Classes</h2>
+          <div className="no-obfuscate rounded bg-yellow-100 p-4">
+            This div has the "no-obfuscate" class which should be excluded
+          </div>
+          <div className="keep-me mt-4 rounded bg-green-100 p-4">
+            This div has "keep-me" which matches "keep-*" pattern
+          </div>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-gray-800 py-8 text-white">
+        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+          <p className="text-gray-400">TailwindCSS Obfuscator - Vite + React Test App</p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/apps/test-vite-react-v5/src/index.css
+++ b/apps/test-vite-react-v5/src/index.css
@@ -1,0 +1,16 @@
+/* Tailwind v4 CSS-first configuration */
+@import "tailwindcss";
+
+/* Custom theme */
+@theme {
+  --color-primary-50: #eff6ff;
+  --color-primary-100: #dbeafe;
+  --color-primary-200: #bfdbfe;
+  --color-primary-300: #93c5fd;
+  --color-primary-400: #60a5fa;
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-primary-700: #1d4ed8;
+  --color-primary-800: #1e40af;
+  --color-primary-900: #1e3a8a;
+}

--- a/apps/test-vite-react-v5/src/main.tsx
+++ b/apps/test-vite-react-v5/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/test-vite-react-v5/tsconfig.json
+++ b/apps/test-vite-react-v5/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/apps/test-vite-react-v5/vite.config.ts
+++ b/apps/test-vite-react-v5/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import tailwindcssObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+    tailwindcssObfuscator({
+      prefix: "tw-",
+      verbose: true,
+      debug: true,
+      preserve: { classes: ["no-obfuscate", "keep-*"] },
+      mapping: {
+        enabled: true,
+        file: ".tw-obfuscation/class-mapping.json",
+        pretty: 2,
+      },
+      cache: {
+        enabled: true,
+        directory: ".tw-obfuscation/cache",
+        strategy: "merge",
+      },
+    }),
+  ],
+});

--- a/apps/test-vite-react-v6/index.html
+++ b/apps/test-vite-react-v6/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Vite React - TailwindCSS Obfuscator</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/test-vite-react-v6/package.json
+++ b/apps/test-vite-react-v6/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "test-vite-react-v6",
+  "version": "1.0.0",
+  "description": "Test app for tailwindcss-obfuscator with Vite v6 + React + Tailwind v4 — regression coverage for the v6 end of our supported peer range (closes part of issue #55).",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^3.0.2"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.6",
+    "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^4.5.1",
+    "@tailwindcss/vite": "^4.2.4",
+    "tailwindcss": "^4.2.4",
+    "tailwindcss-obfuscator": "workspace:*",
+    "typescript": "^5.8.3",
+    "vite": "^6.4.0"
+  }
+}

--- a/apps/test-vite-react-v6/src/App.tsx
+++ b/apps/test-vite-react-v6/src/App.tsx
@@ -1,0 +1,228 @@
+import { useState } from "react";
+import clsx from "clsx";
+import { twMerge } from "tailwind-merge";
+
+// Component with dynamic classes
+function Button({
+  variant = "primary",
+  className,
+  children,
+}: {
+  variant?: "primary" | "secondary";
+  className?: string;
+  children: React.ReactNode;
+}) {
+  const baseClasses = "px-4 py-2 rounded-lg font-semibold transition-colors";
+  const variantClasses = {
+    primary: "bg-blue-500 text-white hover:bg-blue-600",
+    secondary: "bg-gray-200 text-gray-800 hover:bg-gray-300",
+  };
+
+  return (
+    <button className={twMerge(baseClasses, variantClasses[variant], className)}>{children}</button>
+  );
+}
+
+// Component with conditional classes using clsx
+function Alert({
+  type = "info",
+  message,
+}: {
+  type?: "info" | "success" | "warning" | "error";
+  message: string;
+}) {
+  return (
+    <div
+      className={clsx("rounded-lg border p-4", {
+        "border-blue-200 bg-blue-50 text-blue-800": type === "info",
+        "border-green-200 bg-green-50 text-green-800": type === "success",
+        "border-yellow-200 bg-yellow-50 text-yellow-800": type === "warning",
+        "border-red-200 bg-red-50 text-red-800": type === "error",
+      })}
+    >
+      {message}
+    </div>
+  );
+}
+
+// Card component
+function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl bg-white p-6 shadow-lg transition-shadow hover:shadow-xl">
+      <h3 className="mb-4 text-lg font-bold text-gray-900">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+// Grid layout component
+function Grid({ children }: { children: React.ReactNode }) {
+  return <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">{children}</div>;
+}
+
+// Badge component with arbitrary values
+function Badge({ text, color }: { text: string; color: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium bg-${color}-100 text-${color}-800`}
+    >
+      {text}
+    </span>
+  );
+}
+
+// Main App component
+function App() {
+  const [count, setCount] = useState(0);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  return (
+    <div
+      className={clsx(
+        "min-h-screen transition-colors duration-300",
+        theme === "light" ? "bg-gray-100" : "bg-gray-900"
+      )}
+    >
+      {/* Header */}
+      <header className="bg-white shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-gray-900">TailwindCSS Obfuscator Test</h1>
+            <Button
+              variant="secondary"
+              onClick={() => setTheme(theme === "light" ? "dark" : "light")}
+            >
+              Toggle Theme
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      {/* Main content */}
+      <main className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {/* Counter section */}
+        <section className="mb-8">
+          <Card title="Counter Example">
+            <div className="flex items-center gap-4">
+              <Button variant="primary" onClick={() => setCount((c) => c + 1)}>
+                Increment
+              </Button>
+              <span className="font-mono text-xl text-gray-700">{count}</span>
+              <Button variant="secondary" onClick={() => setCount(0)}>
+                Reset
+              </Button>
+            </div>
+          </Card>
+        </section>
+
+        {/* Alerts section */}
+        <section className="mb-8 space-y-4">
+          <h2 className="text-xl font-semibold text-gray-900">Alerts</h2>
+          <Alert type="info" message="This is an info alert" />
+          <Alert type="success" message="This is a success alert" />
+          <Alert type="warning" message="This is a warning alert" />
+          <Alert type="error" message="This is an error alert" />
+        </section>
+
+        {/* Cards grid */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Feature Cards</h2>
+          <Grid>
+            <Card title="Vite Integration">
+              <p className="text-gray-600">Seamless integration with Vite build system</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="Fast" color="green" />
+                <Badge text="Modern" color="blue" />
+              </div>
+            </Card>
+            <Card title="React Support">
+              <p className="text-gray-600">Full support for React components and JSX</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="JSX" color="purple" />
+                <Badge text="Hooks" color="indigo" />
+              </div>
+            </Card>
+            <Card title="Tailwind CSS">
+              <p className="text-gray-600">Works with Tailwind v3 and v4</p>
+              <div className="mt-4 flex gap-2">
+                <Badge text="v3" color="cyan" />
+                <Badge text="v4" color="teal" />
+              </div>
+            </Card>
+          </Grid>
+        </section>
+
+        {/* Responsive utilities test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Responsive Design</h2>
+          <div className="rounded-lg bg-white p-4 shadow">
+            <p className="text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl">
+              This text changes size at different breakpoints
+            </p>
+            <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+              {["red", "orange", "yellow", "green", "blue", "purple"].map((color) => (
+                <div key={color} className={`h-12 rounded bg-${color}-500`} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* State variants test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">State Variants</h2>
+          <div className="flex flex-wrap gap-4">
+            <button className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 focus:ring-2 focus:ring-blue-300 active:bg-blue-700">
+              Hover, Focus, Active
+            </button>
+            <input
+              type="text"
+              placeholder="Focus me"
+              className="rounded border px-4 py-2 focus:border-blue-500 focus:ring-2 focus:ring-blue-200 disabled:bg-gray-100"
+            />
+            <div className="group cursor-pointer rounded bg-gray-100 p-4">
+              <span className="text-gray-600 group-hover:text-blue-600">Group hover effect</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Arbitrary values test */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Arbitrary Values</h2>
+          <div className="space-y-4">
+            <div className="flex h-[100px] w-[300px] items-center justify-center rounded-lg bg-gradient-to-r from-purple-500 to-pink-500">
+              <span className="font-bold text-white">Custom width/height</span>
+            </div>
+            <div className="rounded bg-[#1a1a2e] p-[13px] text-[#eee]">
+              Arbitrary padding and colors
+            </div>
+            <div className="grid grid-cols-[1fr_2fr_1fr] gap-4">
+              <div className="bg-blue-200 p-2 text-center">1fr</div>
+              <div className="bg-blue-300 p-2 text-center">2fr</div>
+              <div className="bg-blue-200 p-2 text-center">1fr</div>
+            </div>
+          </div>
+        </section>
+
+        {/* Class that should NOT be obfuscated */}
+        <section className="mb-8">
+          <h2 className="mb-4 text-xl font-semibold text-gray-900">Excluded Classes</h2>
+          <div className="no-obfuscate rounded bg-yellow-100 p-4">
+            This div has the "no-obfuscate" class which should be excluded
+          </div>
+          <div className="keep-me mt-4 rounded bg-green-100 p-4">
+            This div has "keep-me" which matches "keep-*" pattern
+          </div>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="bg-gray-800 py-8 text-white">
+        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+          <p className="text-gray-400">TailwindCSS Obfuscator - Vite + React Test App</p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/apps/test-vite-react-v6/src/index.css
+++ b/apps/test-vite-react-v6/src/index.css
@@ -1,0 +1,16 @@
+/* Tailwind v4 CSS-first configuration */
+@import "tailwindcss";
+
+/* Custom theme */
+@theme {
+  --color-primary-50: #eff6ff;
+  --color-primary-100: #dbeafe;
+  --color-primary-200: #bfdbfe;
+  --color-primary-300: #93c5fd;
+  --color-primary-400: #60a5fa;
+  --color-primary-500: #3b82f6;
+  --color-primary-600: #2563eb;
+  --color-primary-700: #1d4ed8;
+  --color-primary-800: #1e40af;
+  --color-primary-900: #1e3a8a;
+}

--- a/apps/test-vite-react-v6/src/main.tsx
+++ b/apps/test-vite-react-v6/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/test-vite-react-v6/tsconfig.json
+++ b/apps/test-vite-react-v6/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/apps/test-vite-react-v6/vite.config.ts
+++ b/apps/test-vite-react-v6/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import tailwindcssObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+    tailwindcssObfuscator({
+      prefix: "tw-",
+      verbose: true,
+      debug: true,
+      preserve: { classes: ["no-obfuscate", "keep-*"] },
+      mapping: {
+        enabled: true,
+        file: ".tw-obfuscation/class-mapping.json",
+        pretty: 2,
+      },
+      cache: {
+        enabled: true,
+        directory: ".tw-obfuscation/cache",
+        strategy: "merge",
+      },
+    }),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1155,6 +1155,126 @@ importers:
         specifier: '>=8.0.10'
         version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  apps/test-vite-react-v4:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      react:
+        specifier: ^19.1.0
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.1(react@19.2.1)
+      tailwind-merge:
+        specifier: ^3.0.2
+        version: 3.4.0
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@types/react':
+        specifier: ^19.1.6
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.1
+        version: 4.7.0(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      tailwindcss-obfuscator:
+        specifier: workspace:*
+        version: link:../../packages/tailwindcss-obfuscator
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: '>=8.0.10'
+        version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  apps/test-vite-react-v5:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      react:
+        specifier: ^19.1.0
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.1(react@19.2.1)
+      tailwind-merge:
+        specifier: ^3.0.2
+        version: 3.4.0
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@types/react':
+        specifier: ^19.1.6
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.1
+        version: 4.7.0(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      tailwindcss-obfuscator:
+        specifier: workspace:*
+        version: link:../../packages/tailwindcss-obfuscator
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: '>=8.0.10'
+        version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
+  apps/test-vite-react-v6:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      react:
+        specifier: ^19.1.0
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.1(react@19.2.1)
+      tailwind-merge:
+        specifier: ^3.0.2
+        version: 3.4.0
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@types/react':
+        specifier: ^19.1.6
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.1.5
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^4.5.1
+        version: 4.7.0(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      tailwindcss-obfuscator:
+        specifier: workspace:*
+        version: link:../../packages/tailwindcss-obfuscator
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: '>=8.0.10'
+        version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
   apps/test-vite-react-v7:
     dependencies:
       clsx:


### PR DESCRIPTION
Adds 3 more test apps closing 3/8 sub-tasks of #55. Combined with the existing test-vite-react (v8) + test-vite-react-v7 (PR #114), this gives complete Vite v4-v8 regression coverage. All 5 verified at 100% obfuscation.