### PR TITLE
chore(renovate): disable Dependency Dashboard preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     "security:openssf-scorecard",
-    ":dependencyDashboard",
     ":semanticCommits",
     ":separateMajorReleases",
     "group:monorepos",


### PR DESCRIPTION
Removes the :dependencyDashboard preset from renovate.json so the perpetual dashboard issue stops re-creating itself. Closes #36 effect-wise (Renovate will close the existing issue on next run).