### PR TITLE
chore(renovate): explicit dependencyDashboard:false to kill issue #36

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -78,5 +78,6 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "dependencyDashboard": false
 }


### PR DESCRIPTION
## Summary

- Adds `"dependencyDashboard": false` at the top level of `renovate.json`
- Removing the `:dependencyDashboard` preset from `extends` (PR #124) was insufficient — Renovate's default is `true` when a repo has open dependency alerts, so issue #36 keeps getting re-created
- An explicit override is the only way to permanently silence it

## Test plan

- [x] Renovate dry-run via the CLI confirms dashboard config resolves to `false`
- [ ] After merge, manually close #36 (Renovate will not re-create it)