### PR TITLE
docs(readme): add portfolio link to author section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,7 +1162,7 @@ Built and maintained by **José DA COSTA**.
 <table>
 <tr>
 <td>🌐 Website</td>
-<td><a href="https://www.josedacosta.info">josedacosta.info</a></td>
+<td><a href="https://www.josedacosta.info">josedacosta.info</a> · <a href="https://portfolio.josedacosta.info">portfolio.josedacosta.info</a></td>
 </tr>
 <tr>
 <td>🐙 GitHub</td>


### PR DESCRIPTION
## Summary

- Adds a second link (`portfolio.josedacosta.info`) next to `josedacosta.info` in the « Built and maintained by » author table
- Same cell, separated by middot for visual coherence

## Test plan

- [x] README renders correctly on GitHub