### PR TITLE
docs: replace internal .md filename mentions with proper page links

### DIFF
--- a/docs/reference/labs/tailwind-v4-html.md
+++ b/docs/reference/labs/tailwind-v4-html.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This guide covers class obfuscation for static HTML projects using Tailwind CSS v4. Because `tailwindcss-patch` does NOT work with Tailwind v4 (see `tailwindcss_patch_v4_issues.md`), we use a custom extraction script.
+This guide covers class obfuscation for static HTML projects using Tailwind CSS v4. Because `tailwindcss-patch` does NOT work with Tailwind v4 (see the [Mangle Tailwind v4 Issues](../../research/v4-issues) research page), we use a custom extraction script.
 
 ## Architecture
 
@@ -230,7 +230,7 @@ console.log(`Extracted ${allClasses.size} classes to ${OUTPUT_FILE}`);
 
 ## Why Not tailwindcss-patch?
 
-See `tailwindcss_patch_v4_issues.md` for detailed explanation. In summary:
+See the [Mangle Tailwind v4 Issues](../../research/v4-issues) research page for the detailed explanation. In summary:
 
 1. CLI command `tw-patch extract` fails with module errors
 2. API only detects ~30% of classes

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -16,7 +16,7 @@ If you hit a limitation that is not on this page, please [open an issue](https:/
 
 ### Dynamic template literals (`` `bg-${color}-500` ``)
 
-Marked **❌ Not extracted** in [`compatibility.md` § JSX/React Patterns](./compatibility#class-pattern-support).
+Marked **❌ Not extracted** in the [Compatibility](./compatibility#class-pattern-support) reference (§ JSX/React Patterns).
 
 ::: warning Why dynamic template literals are not extracted
 **Root cause** : the obfuscator extracts class names by **statically analysing source code at build time**. A template literal whose value depends on a runtime variable (e.g. `` `bg-${color}-500` ``) is not knowable until the user's app actually runs — by which point the build has long finished.
@@ -44,7 +44,7 @@ const COLORS = { red: "bg-red-500", blue: "bg-blue-500" };
 
 ### Variable-bound `className={styles}`
 
-Marked **❌ Not extracted** in [`compatibility.md` § JSX/React Patterns](./compatibility#class-pattern-support).
+Marked **❌ Not extracted** in the [Compatibility](./compatibility#class-pattern-support) reference (§ JSX/React Patterns).
 
 ::: warning Why variable-bound className is not extracted
 **Root cause** : same as the template-literal case — the obfuscator does not execute your code, so it cannot know what `styles` resolves to at runtime. Even with sophisticated dataflow analysis, the variable could come from props, a fetch, or a JSON blob — all unknowable at build time.
@@ -95,7 +95,7 @@ Marked **⚠️ Partial** in some scenarios.
 
 ## Framework version coverage
 
-The README advertises a wide design-intent range for several frameworks. The actual versions tested in CI on every release are narrower — see [`compatibility.md` § Version-range claims vs. tested baselines](./compatibility#version-range-claims-vs-tested-baselines) for the exact matrix.
+The README advertises a wide design-intent range for several frameworks. The actual versions tested in CI on every release are narrower — see the [Compatibility](./compatibility#version-range-claims-vs-tested-baselines) reference (§ Version-range claims vs. tested baselines) for the exact matrix.
 
 ### Next.js v13 / v14 / v15 — not in the test matrix
 
@@ -151,11 +151,11 @@ The README advertises a wide design-intent range for several frameworks. The act
 
 ## Tailwind v4 features known to be incomplete
 
-A handful of Tailwind v4 features have less-than-complete support today. The big-picture v4 audit lives in [`docs/research/tailwind-v4-summary.md`](../research/tailwind-v4-summary). Each individual gap below has its own card.
+A handful of Tailwind v4 features have less-than-complete support today. The big-picture v4 audit lives in the [v4 Quick Reference](../research/tailwind-v4-summary) page. Each individual gap below has its own card.
 
 ### Wildcard variants `*:` and `**:` — fully supported as of v2.0.x
 
-Marked `✅` in [`compatibility.md`](./compatibility#tailwind-feature-support). No card needed.
+Marked `✅` in the [Compatibility](./compatibility#tailwind-feature-support) reference. No card needed.
 
 ### Logical-axis utilities (`pbs-*`, `mbs-*`, `inset-bs-*`)
 
@@ -165,7 +165,7 @@ The Tailwind v4 logical-axis utilities (`pbs-4` for padding-block-start, `mbs-2`
 
 ### `not-*` / `in-*` / `nth-*` variants — supported, edge cases possible
 
-Marked **⚠️ Partial** in [`docs/research/tailwind-v4-features-analysis.md`](../research/tailwind-v4-features-analysis).
+Marked **⚠️ Partial** in the [v4 Features Analysis](../research/tailwind-v4-features-analysis) page.
 
 ::: warning Why some uncommon `not-*` / `in-*` / `nth-*` patterns may not extract
 **Root cause** : the basic shapes (`not-hover:bg-blue-500`, `in-data-[state=open]:block`, `nth-2:bg-gray-100`) are all in the test matrix and obfuscate correctly. Combinations with deeply-nested arbitrary values (e.g. `not-[*[data-foo='bar baz']]:flex`) may not extract because the regex doesn't unfold every nesting depth.
@@ -177,7 +177,7 @@ Marked **⚠️ Partial** in [`docs/research/tailwind-v4-features-analysis.md`](
 
 ### CSS variable shorthand `bg-(--my-var)` — supported as of v2.0.x
 
-Marked `✅` in [`compatibility.md`](./compatibility#tailwind-feature-support). Tailwind v4's `bg-(--brand-color)` parentheses shorthand is recognised. No card needed.
+Marked `✅` in the [Compatibility](./compatibility#tailwind-feature-support) reference. Tailwind v4's `bg-(--brand-color)` parentheses shorthand is recognised. No card needed.
 
 ### `@plugin` and `@utility` directives in user-authored CSS
 

--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -44,7 +44,7 @@ flowchart LR
 
 - CSS-first configuration with `@theme` and `@import "tailwindcss"`
 - No `tailwind.config.js` required
-- `tailwindcss-patch` does NOT work (see `tailwindcss_patch_v4_issues.md`)
+- `tailwindcss-patch` does NOT work (see the [Mangle Tailwind v4 Issues](../research/v4-issues) research page)
 - Requires custom extraction script
 - New features: Container queries (`@container`), improved arbitrary values
 
@@ -64,15 +64,14 @@ pnpm build
 pnpm test
 ```
 
-## Documentation Files
+## Related Pages
 
-- `overview.md` - This file
-- `tailwind_v3_html_static.md` - Guide for Tailwind v3 + HTML static
-- `tailwind_v4_html_static.md` - Guide for Tailwind v4 + HTML static
-- `tailwind_v3_react_nextjs.md` - Guide for Tailwind v3 + Next.js
-- `tailwind_v4_react_nextjs.md` - Guide for Tailwind v4 + Next.js
-- `tailwindcss_patch_v4_issues.md` - Why tailwindcss-patch doesn't work with v4
-- `compatibility_matrix.md` - Full compatibility matrix
+- [Tailwind v3 — HTML static](./labs/tailwind-v3-html)
+- [Tailwind v4 — HTML static](./labs/tailwind-v4-html)
+- [Tailwind v3 — Next.js](./labs/tailwind-v3-nextjs)
+- [Tailwind v4 — Next.js](./labs/tailwind-v4-nextjs)
+- [Mangle Tailwind v4 Issues](../research/v4-issues) — why `tailwindcss-patch` doesn't work with v4
+- [Compatibility](./compatibility) — full framework + Tailwind feature matrix
 
 ## Important Rules
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -6,7 +6,7 @@ This directory contains comprehensive research and analysis of Tailwind CSS v4 f
 
 ## Documents Overview
 
-### 1. `tailwind-v4-features-analysis.md` 📖 **FULL REFERENCE**
+### 1. [v4 Features Analysis](./tailwind-v4-features-analysis) 📖 **FULL REFERENCE**
 
 **Purpose:** Complete technical reference for all v4 features and changes
 
@@ -34,7 +34,7 @@ This directory contains comprehensive research and analysis of Tailwind CSS v4 f
 
 ---
 
-### 2. `tailwind-v4-summary.md` ⚡ **QUICK REFERENCE**
+### 2. [v4 Quick Reference](./tailwind-v4-summary) ⚡ **QUICK REFERENCE**
 
 **Purpose:** Quick lookup for v4 changes and patterns
 
@@ -60,7 +60,7 @@ This directory contains comprehensive research and analysis of Tailwind CSS v4 f
 
 ---
 
-### 3. `v4-implementation-checklist.md` ✅ **ACTION PLAN**
+### 3. [v4 Implementation Checklist](./v4-implementation-checklist) ✅ **ACTION PLAN**
 
 **Purpose:** Step-by-step implementation guide with priority order
 
@@ -164,16 +164,8 @@ These **MUST be added** for full v4 support:
 
 ### Step 1: Review Current Status
 
-```bash
-# Read the checklist
-cat v4-implementation-checklist.md
-
-# Check what's already done
-grep -n "✅" v4-implementation-checklist.md
-
-# See what's missing
-grep -n "❌" v4-implementation-checklist.md
-```
+- Open the [v4 Implementation Checklist](./v4-implementation-checklist) page
+- Items already done are marked with ✅; items still needed are marked with ❌
 
 ### Step 2: Choose a Feature to Implement
 
@@ -397,20 +389,11 @@ export default {
 
 ---
 
-## Documentation Structure
+## Related Pages
 
-```
-docs/
-├── research/
-│   ├── README.md (this file)
-│   ├── tailwind-v4-features-analysis.md (full reference)
-│   ├── tailwind-v4-summary.md (quick reference)
-│   └── v4-implementation-checklist.md (action plan)
-├── guide/
-│   └── tailwind-v4-support.md (user-facing guide - TO CREATE)
-└── reference/
-    └── patterns.md (regex patterns reference - TO CREATE)
-```
+- [v4 Features Analysis](./tailwind-v4-features-analysis) — full reference
+- [v4 Quick Reference](./tailwind-v4-summary) — concise lookup
+- [v4 Implementation Checklist](./v4-implementation-checklist) — action plan
 
 ---
 

--- a/docs/research/tailwind-v4-summary.md
+++ b/docs/research/tailwind-v4-summary.md
@@ -1,7 +1,7 @@
 # Tailwind CSS v4 - Quick Reference Summary
 
 **Generated:** 2025-12-08
-**Full Analysis:** See `tailwind-v4-features-analysis.md`
+**Full Analysis:** See [v4 Features Analysis](./tailwind-v4-features-analysis)
 
 ---
 
@@ -278,7 +278,7 @@ Create test files for:
 
 ## References
 
-- **Full Analysis:** `/docs/research/tailwind-v4-features-analysis.md`
+- **Full Analysis:** [v4 Features Analysis](./tailwind-v4-features-analysis)
 - **Tailwind v4 Docs:** https://tailwindcss.com/docs/upgrade-guide
 - **Release Post:** https://tailwindcss.com/blog/tailwindcss-v4
 

--- a/docs/research/v4-implementation-checklist.md
+++ b/docs/research/v4-implementation-checklist.md
@@ -551,8 +551,8 @@ export function detectTailwindVersion(projectRoot: string): "3" | "4" {
 
 ## Related Documents
 
-- **Full Analysis:** `tailwind-v4-features-analysis.md`
-- **Quick Reference:** `tailwind-v4-summary.md`
+- **Full Analysis:** [v4 Features Analysis](./tailwind-v4-features-analysis)
+- **Quick Reference:** [v4 Quick Reference](./tailwind-v4-summary)
 - **Official v4 Upgrade Guide:** https://tailwindcss.com/docs/upgrade-guide
 
 ---


### PR DESCRIPTION
## Summary

- Reader-facing pages were citing internal source filenames (e.g. \`tailwind-v4-features-analysis.md\` as a heading) which feels jarring and unhelpful for end-users
- Switched to proper VitePress relative links using actual page titles (« v4 Features Analysis », « v4 Quick Reference », « v4 Implementation Checklist », « Compatibility », « Mangle Tailwind v4 Issues »)
- Also fixed stale file paths in \`docs/reference/overview.md\` and \`docs/reference/labs/tailwind-v4-html.md\` that pointed to documents renamed long ago

## Files changed

- \`docs/research/README.md\` — section headings use page titles + clickable links
- \`docs/research/tailwind-v4-summary.md\` — \"Full Analysis\" reference updated
- \`docs/research/v4-implementation-checklist.md\` — \"Related Documents\" updated
- \`docs/reference/limitations.md\` — \"Compatibility\" reference cleaned up (4 spots)
- \`docs/reference/overview.md\` — stale \"Documentation Files\" list replaced with working links
- \`docs/reference/labs/tailwind-v4-html.md\` — broken \`tailwindcss_patch_v4_issues.md\` reference fixed

## Test plan

- [ ] After GitHub Pages deploy, verify all newly-introduced links resolve (no 404s)