### PR TITLE
docs(research): flip stale v4 ❌→✅ to reflect shipped support

### DIFF
--- a/.changeset/docs-flip-stale-v4-status.md
+++ b/.changeset/docs-flip-stale-v4-status.md
@@ -1,0 +1,5 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Documentation: corrected the v4 feature-status pages (`research/tailwind-v4-features-analysis`, `research/tailwind-v4-summary`, `research/v4-implementation-checklist`). Most v4 utilities and variants previously labelled « ❌ MISSING » have actually shipped since v2.0.x — the docs were stale. The pages now accurately reflect that wildcard variants, 3D transforms, inset shadows, radial/conic gradients, field-sizing/color-scheme/font-stretch utilities, CSS-variable parens shorthand, arbitrary underscores and the v4 important-suffix syntax are all supported. No code change.

--- a/docs/research/tailwind-v4-features-analysis.md
+++ b/docs/research/tailwind-v4-features-analysis.md
@@ -1316,30 +1316,24 @@ Add the following regex patterns:
 
 ## Document Status
 
-**Current Package Support:**
+**Current Package Support** (audited 2026-04-30 against `packages/tailwindcss-obfuscator/src/core/patterns/`):
 
 - ✅ Container queries (`@sm:`, `@lg:`, `@[500px]:`)
 - ✅ Data attributes (`data-[state=open]:`)
 - ✅ ARIA variants (`aria-[current=page]:`)
 - ✅ Arbitrary values with brackets
 - ✅ CSS variable shorthand (v3 syntax `[--var]`)
-- ⚠️ **PARTIAL** - `not-*`, `in-*`, `nth-*` variants (basic support exists)
-- ❌ **MISSING** - Wildcard selectors (`*:`, `**:`)
-- ❌ **MISSING** - CSS variable parentheses syntax `(--var)`
-- ❌ **MISSING** - Arbitrary values with underscores
-- ❌ **MISSING** - `inset-shadow-*`, `inset-ring-*` utilities
-- ❌ **MISSING** - 3D transform utilities (`rotate-x-*`, `perspective-*`)
-- ❌ **MISSING** - New gradient types (`bg-radial-*`, `bg-conic-*`)
-- ❌ **MISSING** - `field-sizing-*`, `color-scheme-*`, `font-stretch-*`
-- ❌ **MISSING** - Renamed utilities recognition (both v3 and v4)
-- ❌ **MISSING** - Important modifier at END handling
-- ❌ **MISSING** - Nested bracket support (`in-[[data-active]]:`)
+- ✅ Wildcard selectors `*:` and `**:` — `variants.ts`
+- ✅ CSS variable parentheses syntax `bg-(--brand)`, `text-(color:--my-var)` — `validators.ts`
+- ✅ Arbitrary values with underscores `grid-cols-[max-content_auto]` — `validators.ts`
+- ✅ `inset-shadow-*`, `inset-ring-*` utilities — `utilities.ts`
+- ✅ 3D transform utilities (`rotate-x-*`, `rotate-y-*`, `rotate-z-*`, `scale-z-*`, `translate-z-*`, `perspective-*`, `perspective-origin-*`, `transform-3d`) — `utilities.ts`
+- ✅ New gradient types (`bg-radial-*`, `bg-conic-*`) — `utilities.ts`
+- ✅ `field-sizing-*`, `color-scheme-*`, `font-stretch-*` — `utilities.ts`
+- ✅ Renamed utilities recognition (both v3 names like `flex-shrink` and v4 names like `shrink`) — `utilities.ts`
+- ✅ Important modifier at END (`flex!` accepted alongside `!flex`) — `validators.ts`
+- ✅ Nested bracket support (`in-[[data-active]]:`) — basic patterns work; deeply-nested edge cases see [Limitations](../reference/limitations#not-in-nth-variants-supported-edge-cases-possible)
+- ⚠️ **PARTIAL** — `not-*`, `in-*`, `nth-*` variants : basic shapes covered, deeply-nested arbitrary values may not extract — see [Limitations](../reference/limitations#not-in-nth-variants-supported-edge-cases-possible)
+- ⚠️ **PARTIAL** — `tv()` (tailwind-variants) : simple flat patterns work, composed variants may break — tracked in [issue #61](https://github.com/josedacosta/tailwindcss-obfuscator/issues/61) and [Limitations](../reference/limitations)
 
-**Next Steps:**
-
-1. Update `VARIANT_PREFIXES` array with v4 variants
-2. Update `STATIC_UTILITIES` set with new utilities
-3. Update `FUNCTIONAL_UTILITY_PREFIXES` array with new prefixes
-4. Add regex patterns to `isTailwindClass()` for v4 patterns
-5. Update transformers to preserve variant order and important position
-6. Add comprehensive test suite for v4 patterns
+**Verification** : every check above is exercised by [`tests/tailwind-v4-patterns.test.ts`](https://github.com/josedacosta/tailwindcss-obfuscator/blob/main/packages/tailwindcss-obfuscator/tests/tailwind-v4-patterns.test.ts) and [`tests/comprehensive-patterns.test.ts`](https://github.com/josedacosta/tailwindcss-obfuscator/blob/main/packages/tailwindcss-obfuscator/tests/comprehensive-patterns.test.ts) (44 + 86 cases).

--- a/docs/research/tailwind-v4-summary.md
+++ b/docs/research/tailwind-v4-summary.md
@@ -173,21 +173,24 @@ bg-(?:radial|conic)-[\w\[\]-]+
 - `in-*` variants (basic patterns)
 - `nth-*` variants (basic patterns)
 
-### ❌ Missing Support (Must Add)
+### ✅ Now Supported (was « Missing » in earlier drafts of this page)
 
-**High Priority:**
+The package was audited end-to-end on 2026-04-30 against `packages/tailwindcss-obfuscator/src/core/patterns/`. Every item below ships in the current release :
 
-1. Wildcard selectors (`*:`, `**:`)
-2. CSS variable parentheses syntax `(--var)`
-3. Arbitrary values with underscores
-4. Named container queries (`@lg/sidebar:`)
-5. Nested brackets (`in-[[data-active]]:`)
-6. Important modifier at END enforcement
-7. Variant order preservation (left-to-right)
-
-**Medium Priority:** 8. 3D transform utilities (`rotate-x-*`, `perspective-*`) 9. Inset shadow/ring utilities 10. New gradient types (`bg-radial-*`, `bg-conic-*`) 11. Gradient stop positions (`to-75%`) 12. Renamed utility recognition (both v3 and v4)
-
-**Low Priority:** 13. `field-sizing-*` utilities 14. `color-scheme-*` utilities 15. `font-stretch-*` utilities 16. Dynamic grid columns (`grid-cols-15`)
+1. Wildcard selectors (`*:`, `**:`) — `variants.ts`
+2. CSS variable parentheses syntax `bg-(--var)`, `text-(color:--my-var)` — `validators.ts`
+3. Arbitrary values with underscores — `validators.ts`
+4. Named container queries (`@lg/sidebar:`) — `variants.ts`
+5. Nested brackets (`in-[[data-active]]:`) — basic patterns work, deeply-nested cases see [Limitations](../reference/limitations#not-in-nth-variants-supported-edge-cases-possible)
+6. Important modifier at END (`flex!`) — `validators.ts` accepts both positions
+7. Variant order preservation — transformer is order-preserving by design
+8. 3D transform utilities (`rotate-x-*`, `rotate-y-*`, `rotate-z-*`, `perspective-*`, `transform-3d`) — `utilities.ts`
+9. Inset shadow / inset ring utilities — `utilities.ts`
+10. New gradient types (`bg-radial-*`, `bg-conic-*`) — `utilities.ts`
+11. Gradient stop positions (`to-75%`) — handled by the standard percentage utility regex
+12. Renamed utility recognition (both v3 names like `flex-shrink` and v4 names like `shrink`) — `utilities.ts`
+13. `field-sizing-*`, `color-scheme-*`, `font-stretch-*` utilities — `utilities.ts`
+14. Dynamic grid columns (`grid-cols-15`) — handled by the standard arbitrary-value regex
 
 ---
 

--- a/docs/research/v4-implementation-checklist.md
+++ b/docs/research/v4-implementation-checklist.md
@@ -1,38 +1,66 @@
-# Tailwind CSS v4 - Implementation Checklist
+# Tailwind CSS v4 — Implementation History
 
-**Status:** In Progress
-**Updated:** 2025-12-08
+**Status:** ✅ All originally-listed items have shipped (audited 2026-04-30)
+**Original checklist date:** 2025-12-08
 **Package:** tailwindcss-obfuscator
+
+::: tip This page is now historical
+This document was the original « what's missing for v4 support » checklist written in late 2025. Every item below is now implemented and shipped. The page is preserved so future contributors can see the design rationale and code-location pointers — but for **current support status**, please use :
+
+- [v4 Features Analysis](./tailwind-v4-features-analysis) — full reference, with ✅/⚠️ status reflecting today's code
+- [v4 Quick Reference](./tailwind-v4-summary) — concise lookup
+- [Compatibility](../reference/compatibility) — tested-version matrix
+- [Limitations](../reference/limitations) — actual remaining gaps with explanation cards
+  :::
 
 ---
 
-## Current Implementation Status
+## Current Implementation Status (2026-04-30)
 
-### ✅ Already Implemented (Confirmed by Code Review)
+Everything in this checklist ships in the current release. The summary :
 
-#### Variants
+#### Variants — all implemented
 
 - ✅ Container queries: `@sm:`, `@md:`, `@lg:`, `@xl:`, `@2xl:`
 - ✅ Container min/max: `@min-[400px]:`, `@max-[800px]:`
 - ✅ Named containers: `@lg/sidebar:`, `@[500px]/card:`
 - ✅ Data attributes: `data-[state=open]:`, `data-disabled:`
 - ✅ ARIA variants: `aria-[current=page]:`, `aria-pressed:`
-- ✅ `not-*` variants: `not-hover:`, `not-focus:` (basic support)
-- ✅ `in-*` variants: `in-hover:`, `in-data-[state=open]:` (basic support)
+- ✅ `not-*` variants: `not-hover:`, `not-focus:` — basic shapes; deeply-nested edge cases see [Limitations](../reference/limitations)
+- ✅ `in-*` variants: `in-hover:`, `in-data-[state=open]:` — basic shapes
 - ✅ `nth-*` variants: `nth-1:`, `nth-[2n+1]:`, `nth-even:`, `nth-odd:`
-- ✅ Nested brackets: `in-[[data-active]]:` (pattern exists)
+- ✅ Nested brackets: `in-[[data-active]]:`
+- ✅ Wildcard variants: `*:`, `**:` — `src/core/patterns/variants.ts`
 
-#### Utilities
+#### Utilities — all implemented
 
 - ✅ Arbitrary values: `bg-[#1da1f2]`, `w-[calc(100%-2rem)]`
+- ✅ Arbitrary values with underscores: `grid-cols-[max-content_auto]`
 - ✅ Opacity modifiers: `bg-blue-500/50`, `text-white/75`
 - ✅ CSS variables (v3 syntax): `bg-[var(--my-color)]`
+- ✅ CSS variables (v4 parens): `bg-(--brand)`, `text-(color:--my-var)`
+- ✅ Important modifier: both `!flex` and `flex!` accepted
+- ✅ 3D transforms: `rotate-x-*`, `rotate-y-*`, `rotate-z-*`, `scale-z-*`, `translate-z-*`, `perspective-*`, `transform-3d`
+- ✅ Inset shadows / inset rings: `inset-shadow-*`, `inset-ring-*`
+- ✅ New gradients: `bg-radial-*`, `bg-conic-*`, gradient stop positions like `to-75%`
+- ✅ Field sizing, color scheme, font stretch
+- ✅ Renamed utilities: both v3 (`flex-shrink`) and v4 (`shrink`) names recognized
 
-#### Code Locations
+#### Known partial / not-fully-stable
 
-- `src/extractors/base.ts` lines 148-206: VARIANT_PREFIXES includes v4 variants
-- `src/extractors/base.ts` lines 1206-1227: Variant patterns for not/in/nth
-- `src/extractors/base.ts` lines 1044-1051: Container query patterns
+- ⚠️ `tv()` (tailwind-variants) : simple flat patterns work, composed variants may break — tracked in [issue #61](https://github.com/josedacosta/tailwindcss-obfuscator/issues/61) and the [Limitations](../reference/limitations) page.
+
+#### Code locations (current)
+
+- `src/core/patterns/variants.ts` — all variant prefixes including v4 wildcards
+- `src/core/patterns/utilities.ts` — every static + functional utility (3D, gradients, inset, etc.)
+- `src/core/patterns/validators.ts` — arbitrary-value regex (with underscores) + important-suffix tolerance + CSS-variable parens
+
+---
+
+## Below this line — original « to-do » sections (kept for historical context)
+
+The remaining sections of this page describe what was missing **at the time of writing in December 2025**. They are no longer accurate as a roadmap. Read them only to understand the design discussions that led to today's implementation.
 
 ---
 


### PR DESCRIPTION
## Summary

The three v4 research pages were written in late 2025 as a « what's missing » planning checklist. **Most items have shipped since v2.0.x but the docs were never updated**, leaving readers with the impression that core v4 features are not supported when they all are.

Audited 2026-04-30 against:
- \`packages/tailwindcss-obfuscator/src/core/patterns/utilities.ts\`
- \`packages/tailwindcss-obfuscator/src/core/patterns/validators.ts\`
- \`packages/tailwindcss-obfuscator/src/core/patterns/variants.ts\`
- \`packages/tailwindcss-obfuscator/tests/tailwind-v4-patterns.test.ts\`

## Features flipped from ❌ to ✅

| Feature | Now-correct status | Code location |
|---|---|---|
| Wildcard variants \`*:\` \`**:\` | ✅ | \`variants.ts:111-113\` |
| 3D transforms (\`rotate-x/y/z\`, \`scale-z\`, \`translate-z\`, \`perspective\`, \`transform-3d\`) | ✅ | \`utilities.ts\` + \`validators.ts:66-69\` |
| Inset shadows / inset rings | ✅ | \`utilities.ts\` |
| Radial / conic gradients | ✅ | \`utilities.ts\` |
| Field sizing, color scheme, font stretch | ✅ | \`utilities.ts\` |
| CSS variable parens \`bg-(--var)\` | ✅ | \`validators.ts:47\` |
| Arbitrary underscores \`grid-cols-[max_auto]\` | ✅ | \`validators.ts:23\` |
| Important suffix \`flex!\` | ✅ | \`validators.ts:132\` (both positions accepted) |
| Renamed utilities (v3↔v4 names) | ✅ | \`utilities.ts\` |

## Honestly remaining

- ⚠️ \`tv()\` (tailwind-variants) — simple flat patterns work, composed variants may break (issue #61, see Limitations page).
- ⚠️ Deeply-nested \`not-/in-/nth-\` arbitrary values — basic shapes covered, deeply-nested edge cases noted in Limitations.

## Test plan

- [x] \`grep -rn '❌ MISSING' docs/research/ docs/reference/\` returns 0 hits
- [x] Top of each page now reflects 2026-04-30 audit truth
- [x] Historical content preserved below explicit « no longer accurate » banner