### PR TITLE
docs(reference): tv() is supported, not broken (issue #61 closed)

### DIFF
--- a/.changeset/docs-tv-actually-supported.md
+++ b/.changeset/docs-tv-actually-supported.md
@@ -1,0 +1,5 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Documentation: removed the stale « tv() currently broken » card on the Limitations page. The fix shipped in PR #63 (issue #61 closed) on 2026-04-29 and is verified end-to-end on every release by `apps/test-tailwind-variants/`. The card now correctly says supported, with a single noted caveat (multi-element `slot` API not yet in test matrix).

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -78,17 +78,14 @@ Marked **⚠️ Partial** in some scenarios.
 **Tracked in** : the security trade-off is intentional. The pre-PR-#45 form would freeze a downstream user's build with a malformed Vue file.
 :::
 
-### `tv()` (tailwind-variants) base + variants + compoundVariants
+### `tv()` (tailwind-variants) base + variants + compoundVariants — supported as of v2.x
 
-::: danger Currently broken — fix in flight
-**Root cause** : the regex in `packages/tailwindcss-obfuscator/src/extractors/jsx.ts:386-409` matches the surface form `tv({ base: "..." })` but in practice does not pick up the variant strings. Discovered while building [`apps/test-tailwind-variants/`](https://github.com/josedacosta/tailwindcss-obfuscator/issues/61) — only inline template-literal classes get obfuscated, the entire `base` / `variants` / `compoundVariants` content is left as raw `bg-blue-600` / `text-white` etc.
+::: tip Status : working end-to-end since [PR #63](https://github.com/josedacosta/tailwindcss-obfuscator/pull/63) (issue #61 closed)
+The `base`, `variants`, `compoundVariants` and `defaultVariants` keys of a `tv({ … })` call are extracted and obfuscated. The end-to-end regression is exercised on every release by [`apps/test-tailwind-variants/`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-tailwind-variants), which fails the build if any of the 33 classes in the suite ship un-obfuscated.
 
-**Workaround until fixed** : either
+**Known caveat** : the multi-element `slot` API (`tv({ slots: { … }, variants: { … } })`) is not yet covered by the test matrix. If you rely on slots, audit your built CSS and open an issue if a class slips through — extending the AST visitor to slots is a small follow-up.
 
-- inline the variant strings as constants and reference them (the AST extractor _can_ follow same-file constants),
-- or use [`cva()`](https://cva.style/) instead of `tv()` — `cva()` works correctly today and is exercised end-to-end in [`apps/test-shadcn-ui/`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-shadcn-ui).
-
-**Tracked in** : [issue #61](https://github.com/josedacosta/tailwindcss-obfuscator/issues/61). README claim "`tv()` recognised out of the box" is currently misleading — will be re-honored once #61 ships.
+**Alternative** : [`cva()`](https://cva.style/) is also fully supported and is exercised end-to-end in [`apps/test-shadcn-ui/`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-shadcn-ui).
 :::
 
 ---

--- a/docs/research/tailwind-v4-features-analysis.md
+++ b/docs/research/tailwind-v4-features-analysis.md
@@ -1334,6 +1334,6 @@ Add the following regex patterns:
 - ✅ Important modifier at END (`flex!` accepted alongside `!flex`) — `validators.ts`
 - ✅ Nested bracket support (`in-[[data-active]]:`) — basic patterns work; deeply-nested edge cases see [Limitations](../reference/limitations#not-in-nth-variants-supported-edge-cases-possible)
 - ⚠️ **PARTIAL** — `not-*`, `in-*`, `nth-*` variants : basic shapes covered, deeply-nested arbitrary values may not extract — see [Limitations](../reference/limitations#not-in-nth-variants-supported-edge-cases-possible)
-- ⚠️ **PARTIAL** — `tv()` (tailwind-variants) : simple flat patterns work, composed variants may break — tracked in [issue #61](https://github.com/josedacosta/tailwindcss-obfuscator/issues/61) and [Limitations](../reference/limitations)
+- ✅ `tv()` (tailwind-variants) — `base`, `variants`, `compoundVariants` and `defaultVariants` extracted end-to-end (PR #63 / issue #61 closed). Multi-element `slot` API not yet in the test matrix — see [Limitations](../reference/limitations#tv-tailwind-variants-base-variants-compoundvariants-supported-as-of-v2-x)
 
 **Verification** : every check above is exercised by [`tests/tailwind-v4-patterns.test.ts`](https://github.com/josedacosta/tailwindcss-obfuscator/blob/main/packages/tailwindcss-obfuscator/tests/tailwind-v4-patterns.test.ts) and [`tests/comprehensive-patterns.test.ts`](https://github.com/josedacosta/tailwindcss-obfuscator/blob/main/packages/tailwindcss-obfuscator/tests/comprehensive-patterns.test.ts) (44 + 86 cases).

--- a/docs/research/v4-implementation-checklist.md
+++ b/docs/research/v4-implementation-checklist.md
@@ -48,7 +48,7 @@ Everything in this checklist ships in the current release. The summary :
 
 #### Known partial / not-fully-stable
 
-- ⚠️ `tv()` (tailwind-variants) : simple flat patterns work, composed variants may break — tracked in [issue #61](https://github.com/josedacosta/tailwindcss-obfuscator/issues/61) and the [Limitations](../reference/limitations) page.
+- ✅ `tv()` (tailwind-variants) : `base`, `variants`, `compoundVariants` and `defaultVariants` extracted end-to-end (PR #63 / issue #61 closed). Slots API not yet in the test matrix — see the [tv() card in Limitations](../reference/limitations#tv-tailwind-variants-base-variants-compoundvariants-supported-as-of-v2-x).
 
 #### Code locations (current)
 


### PR DESCRIPTION
## Summary

The Limitations page had a « tv() Currently broken — fix in flight » \`::: danger\` card that was written **before** [PR #63](https://github.com/josedacosta/tailwindcss-obfuscator/pull/63) shipped (2026-04-29, closes [issue #61](https://github.com/josedacosta/tailwindcss-obfuscator/issues/61)). The end-to-end regression in [\`apps/test-tailwind-variants/\`](https://github.com/josedacosta/tailwindcss-obfuscator/tree/main/apps/test-tailwind-variants) confirms all 33 \`base\` + \`variants\` + \`compoundVariants\` classes get extracted and obfuscated — \`pnpm --filter test-tailwind-variants build\` ends with « ✅ PASS: all 33 tv() classes extracted and obfuscated ».

## Changes

- \`docs/reference/limitations.md\` — \`::: danger Currently broken\` card replaced with \`::: tip Status: working since PR #63\` card. Honest caveat retained for the multi-element \`slot\` API which is not yet in the test matrix.
- \`docs/research/v4-implementation-checklist.md\` — banner row updated from ⚠️ to ✅
- \`docs/research/tailwind-v4-features-analysis.md\` — Document Status row updated from ⚠️ to ✅

## Test plan

- [x] \`pnpm --filter test-tailwind-variants build\` → green, 33 classes extracted
- [x] No code touched