### PR TITLE
feat(ci): weekly version-watch cron with email or issue alerts

### DIFF
--- a/.changeset/feat-version-watch-cron.md
+++ b/.changeset/feat-version-watch-cron.md
@@ -1,0 +1,5 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+CI: added a weekly version-watch cron (`Monday 08:00 UTC`) that surveils every package this project supports for SemVer-major bumps OR explicit breaking-change keywords in upstream release notes. Anti-overkill: patches and minors are intentionally not surfaced (Renovate handles those). Notification path is SMTP email when `SMTP_*` secrets are configured, GitHub-issue fallback otherwise. Adjustable via `.github/version-watch-config.json`.

--- a/.github/version-watch-config.json
+++ b/.github/version-watch-config.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "./version-watch-schema.json",
+  "description": "Watchlist for the version-watch workflow. The workflow alerts on SemVer-major bumps OR breaking-change keywords in upstream release notes. Patches and minors are intentionally NOT alerted on (Renovate handles those routinely).",
+  "packages": [
+    {
+      "name": "tailwindcss",
+      "currentMajor": 4,
+      "alertOn": ["major", "breaking"],
+      "githubRepo": "tailwindlabs/tailwindcss"
+    },
+    {
+      "name": "@tailwindcss/vite",
+      "currentMajor": 4,
+      "alertOn": ["major"],
+      "githubRepo": "tailwindlabs/tailwindcss"
+    },
+    {
+      "name": "@tailwindcss/postcss",
+      "currentMajor": 4,
+      "alertOn": ["major"],
+      "githubRepo": "tailwindlabs/tailwindcss"
+    },
+    { "name": "vite", "currentMajor": 8, "alertOn": ["major"], "githubRepo": "vitejs/vite" },
+    {
+      "name": "next",
+      "currentMajor": 16,
+      "alertOn": ["major", "breaking"],
+      "githubRepo": "vercel/next.js"
+    },
+    { "name": "nuxt", "currentMajor": 4, "alertOn": ["major"], "githubRepo": "nuxt/nuxt" },
+    { "name": "astro", "currentMajor": 6, "alertOn": ["major"], "githubRepo": "withastro/astro" },
+    {
+      "name": "@sveltejs/kit",
+      "currentMajor": 2,
+      "alertOn": ["major"],
+      "githubRepo": "sveltejs/kit"
+    },
+    { "name": "svelte", "currentMajor": 5, "alertOn": ["major"], "githubRepo": "sveltejs/svelte" },
+    {
+      "name": "@rspack/core",
+      "currentMajor": 2,
+      "alertOn": ["major"],
+      "githubRepo": "web-infra-dev/rspack"
+    },
+    {
+      "name": "@farmfe/core",
+      "currentMajor": 1,
+      "alertOn": ["major"],
+      "githubRepo": "farm-fe/farm"
+    },
+    { "name": "rollup", "currentMajor": 4, "alertOn": ["major"], "githubRepo": "rollup/rollup" },
+    { "name": "webpack", "currentMajor": 5, "alertOn": ["major"], "githubRepo": "webpack/webpack" },
+    {
+      "name": "esbuild",
+      "currentMajor": 0,
+      "alertOn": ["major", "breaking"],
+      "githubRepo": "evanw/esbuild"
+    },
+    {
+      "name": "@babel/parser",
+      "currentMajor": 7,
+      "alertOn": ["major"],
+      "githubRepo": "babel/babel"
+    },
+    {
+      "name": "vitest",
+      "currentMajor": 4,
+      "alertOn": ["major"],
+      "githubRepo": "vitest-dev/vitest"
+    },
+    {
+      "name": "typescript",
+      "currentMajor": 5,
+      "alertOn": ["major"],
+      "githubRepo": "microsoft/TypeScript"
+    },
+    { "name": "react", "currentMajor": 19, "alertOn": ["major"], "githubRepo": "facebook/react" },
+    { "name": "vue", "currentMajor": 3, "alertOn": ["major"], "githubRepo": "vuejs/core" },
+    { "name": "solid-js", "currentMajor": 1, "alertOn": ["major"], "githubRepo": "solidjs/solid" },
+    { "name": "qwik", "currentMajor": 1, "alertOn": ["major"], "githubRepo": "QwikDev/qwik" },
+    {
+      "name": "tailwind-variants",
+      "currentMajor": 0,
+      "alertOn": ["major", "breaking"],
+      "githubRepo": "heroui-inc/tailwind-variants"
+    },
+    {
+      "name": "class-variance-authority",
+      "currentMajor": 0,
+      "alertOn": ["major"],
+      "githubRepo": "joe-bell/cva"
+    }
+  ]
+}

--- a/.github/workflows/version-watch.yml
+++ b/.github/workflows/version-watch.yml
@@ -1,0 +1,83 @@
+name: Version Watch
+
+# Surveils every package this project supports for SemVer-major bumps OR
+# explicit breaking-change keywords in the upstream release notes. Anti-
+# overkill: patches and minors are NOT surfaced (Renovate handles those).
+#
+# When something needs human attention, the maintainer is notified through:
+#   1. SMTP email to contact@josedacosta.info, when SMTP_* secrets are set
+#   2. A GitHub issue with the `version-watch` label, otherwise (fallback)
+#
+# To acknowledge an alert and silence it for the next major: bump
+# `currentMajor` in `.github/version-watch-config.json` and merge.
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # every Monday at 08:00 UTC (after the OSSF Scorecard run)
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run without sending email or opening an issue (logs the report only)"
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  watch:
+    name: Check upstream versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read the watchlist
+      issues: write # fallback notification channel
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Run version watcher
+        id: watch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/version-watch.mjs
+
+      - name: Send email notification (when SMTP secrets are configured)
+        if: ${{ steps.watch.outputs.alertCountIsPositive == 'true' && env.SMTP_HOST != '' && inputs.dry-run != true }}
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+        uses: dawidd6/action-send-mail@2cea9617b09d79a095af21254fbcb7ae95903dde # v3.12.0
+        with:
+          server_address: ${{ secrets.SMTP_HOST }}
+          server_port: ${{ secrets.SMTP_PORT }}
+          username: ${{ secrets.SMTP_USER }}
+          password: ${{ secrets.SMTP_PASS }}
+          from: tailwindcss-obfuscator version-watch <${{ secrets.SMTP_USER }}>
+          to: contact@josedacosta.info
+          subject: "[tailwindcss-obfuscator] ${{ steps.watch.outputs.alertCount }} upstream major/breaking version(s) detected"
+          body: ${{ steps.watch.outputs.report }}
+          convert_markdown: true
+
+      - name: Fallback — open a GitHub issue (when no SMTP config OR email step skipped)
+        if: ${{ steps.watch.outputs.alertCountIsPositive == 'true' && env.SMTP_HOST == '' && inputs.dry-run != true }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPORT: ${{ steps.watch.outputs.report }}
+          ALERT_COUNT: ${{ steps.watch.outputs.alertCount }}
+        run: |
+          # Reuse the existing open issue with the version-watch label, if any.
+          existing=$(gh issue list --label version-watch --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$REPORT"
+          else
+            gh issue create \
+              --title "[version-watch] $ALERT_COUNT upstream major/breaking version(s) detected" \
+              --label version-watch \
+              --body "$REPORT"
+          fi

--- a/scripts/version-watch.mjs
+++ b/scripts/version-watch.mjs
@@ -1,0 +1,264 @@
+#!/usr/bin/env node
+/**
+ * Version watcher — surveils every package this project supports for
+ * SemVer-major bumps OR explicit breaking-change keywords in the upstream
+ * release notes. Designed to run weekly via .github/workflows/version-watch.yml.
+ *
+ * Anti-overkill carve-out
+ * ───────────────────────
+ * Renovate already handles minor / patch bumps as routine PRs. This script
+ * is INTENTIONALLY noisy on majors / breaking changes only — those are the
+ * cases that warrant human attention (audit our adapter, plan a v3 of the
+ * package, update test apps). It does NOT alert on:
+ *   - patch (x.y.PATCH)
+ *   - minor (x.MINOR.z) when no breaking-change keyword is present
+ *   - prereleases (alpha / beta / rc) on majors that are still in flight
+ *
+ * Output
+ * ──────
+ * Writes a Markdown report to stdout AND to $GITHUB_OUTPUT (multi-line) so
+ * the workflow can email it via dawidd6/action-send-mail OR open a
+ * GitHub issue if SMTP secrets are absent.
+ *
+ * Local dry-run
+ * ─────────────
+ *   node scripts/version-watch.mjs --dry-run
+ *
+ * Exit codes : 0 always (a workflow failure here would be obnoxious — the
+ * report is the signal, not the exit code).
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const CONFIG_PATH = path.join(repoRoot, ".github", "version-watch-config.json");
+
+const BREAKING_KEYWORDS = [
+  "BREAKING CHANGE",
+  "BREAKING:",
+  "Breaking change",
+  "💥",
+  "BREAKING-CHANGE",
+];
+
+/**
+ * Light wrapper over fetch that times out after 15s and returns null on
+ * failure (so one flaky upstream API doesn't sink the whole report).
+ */
+async function fetchJson(url, headers = {}) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 15_000);
+  try {
+    const res = await fetch(url, {
+      headers: { "user-agent": "tailwindcss-obfuscator-version-watch", ...headers },
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function parseMajor(version) {
+  if (typeof version !== "string") return null;
+  // Strip leading "v" and any prerelease suffix, then take the first digit run.
+  const cleaned = version.replace(/^v/, "");
+  const match = cleaned.match(/^(\d+)\./);
+  return match ? Number(match[1]) : null;
+}
+
+function isPrerelease(version) {
+  return typeof version === "string" && /-(alpha|beta|rc|next|canary|nightly|pre)/i.test(version);
+}
+
+async function checkPackage(pkg, githubToken) {
+  const npm = await fetchJson(`https://registry.npmjs.org/${encodeURIComponent(pkg.name)}`);
+  if (!npm) return { name: pkg.name, status: "fetch-failed" };
+
+  const latestTag = npm["dist-tags"]?.latest;
+  if (!latestTag) return { name: pkg.name, status: "no-latest-tag" };
+
+  const latestMajor = parseMajor(latestTag);
+  if (latestMajor === null) {
+    return { name: pkg.name, status: "unparseable-version", version: latestTag };
+  }
+
+  const result = {
+    name: pkg.name,
+    currentMajor: pkg.currentMajor,
+    latestVersion: latestTag,
+    latestMajor,
+    isPrerelease: isPrerelease(latestTag),
+    alerts: [],
+  };
+
+  // 1. SemVer-major detection.
+  if (pkg.alertOn.includes("major") && latestMajor > pkg.currentMajor && !result.isPrerelease) {
+    result.alerts.push({
+      kind: "major",
+      message: `New major: v${pkg.currentMajor} → v${latestMajor} (full version: ${latestTag})`,
+    });
+  }
+
+  // 2. Breaking-change detection in release notes (only if requested AND a GH repo is mapped).
+  if (pkg.alertOn.includes("breaking") && pkg.githubRepo && githubToken) {
+    const releases = await fetchJson(
+      `https://api.github.com/repos/${pkg.githubRepo}/releases?per_page=5`,
+      { authorization: `Bearer ${githubToken}`, accept: "application/vnd.github+json" }
+    );
+    if (Array.isArray(releases)) {
+      for (const release of releases) {
+        const body = String(release.body ?? "");
+        const tag = String(release.tag_name ?? "");
+        const tagMajor = parseMajor(tag);
+        if (tagMajor === null || tagMajor <= pkg.currentMajor) continue;
+        const matchedKeyword = BREAKING_KEYWORDS.find((k) =>
+          body.toUpperCase().includes(k.toUpperCase())
+        );
+        if (matchedKeyword) {
+          const excerpt = body
+            .split("\n")
+            .filter((line) => line.toUpperCase().includes(matchedKeyword.toUpperCase()))
+            .slice(0, 3)
+            .join("\n");
+          result.alerts.push({
+            kind: "breaking",
+            tag,
+            url: release.html_url,
+            keyword: matchedKeyword,
+            excerpt: excerpt.length > 800 ? excerpt.slice(0, 800) + " …" : excerpt,
+          });
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+function renderReport(results, generatedAt) {
+  const alerts = results.filter((r) => r.alerts && r.alerts.length > 0);
+  const noAction = results.filter((r) => !r.alerts || r.alerts.length === 0);
+  const failed = results.filter((r) => r.status && r.status !== "ok");
+
+  const lines = [];
+  lines.push(`# Version Watch Report — ${generatedAt}`);
+  lines.push("");
+  lines.push(
+    "_The watcher only alerts on **SemVer-major** bumps OR explicit **breaking-change** keywords in upstream release notes. Patch / minor bumps are handled by Renovate and are not surfaced here._"
+  );
+  lines.push("");
+
+  if (alerts.length === 0) {
+    lines.push("## ✅ Nothing to flag");
+    lines.push("");
+    lines.push(`All ${results.length} watched packages are within their current major.`);
+  } else {
+    lines.push(`## 🚨 ${alerts.length} package(s) need attention`);
+    lines.push("");
+    for (const r of alerts) {
+      lines.push(`### \`${r.name}\` (current major: v${r.currentMajor})`);
+      lines.push("");
+      for (const a of r.alerts) {
+        if (a.kind === "major") {
+          lines.push(`- **Major bump detected** : ${a.message}`);
+          lines.push(`  - npm : https://www.npmjs.com/package/${r.name}`);
+        } else if (a.kind === "breaking") {
+          lines.push(`- **Breaking change** in \`${a.tag}\` (matched keyword \`${a.keyword}\`)`);
+          if (a.url) lines.push(`  - Release notes : ${a.url}`);
+          if (a.excerpt) {
+            lines.push("  - Excerpt :");
+            for (const ex of a.excerpt.split("\n")) {
+              lines.push(`    > ${ex}`);
+            }
+          }
+        }
+      }
+      lines.push("");
+      lines.push(
+        `_To acknowledge this alert, bump \`currentMajor\` in \`.github/version-watch-config.json\`._`
+      );
+      lines.push("");
+    }
+  }
+
+  if (failed.length > 0) {
+    lines.push("## ⚠️ Could not check");
+    lines.push("");
+    for (const r of failed) {
+      lines.push(`- \`${r.name}\` — ${r.status}`);
+    }
+    lines.push("");
+  }
+
+  if (noAction.length > 0) {
+    lines.push(`## ✅ ${noAction.length} package(s) on current major (no action needed)`);
+    lines.push("");
+    lines.push(noAction.map((r) => `\`${r.name}@${r.latestVersion ?? "?"}\``).join(" · "));
+    lines.push("");
+  }
+
+  lines.push("---");
+  lines.push("");
+  lines.push(
+    "_Generated by `scripts/version-watch.mjs`. Edit the watchlist at `.github/version-watch-config.json`._"
+  );
+
+  return lines.join("\n");
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const githubToken = process.env.GITHUB_TOKEN ?? null;
+
+  if (!fs.existsSync(CONFIG_PATH)) {
+    console.error(`version-watch: config file not found at ${CONFIG_PATH}`);
+    process.exit(0);
+  }
+  const config = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+  if (!Array.isArray(config.packages) || config.packages.length === 0) {
+    console.error("version-watch: empty packages array in config");
+    process.exit(0);
+  }
+
+  const generatedAt = new Date().toISOString().slice(0, 10);
+  const results = [];
+  for (const pkg of config.packages) {
+    const r = await checkPackage(pkg, githubToken);
+    results.push(r);
+  }
+
+  const report = renderReport(results, generatedAt);
+  const alertCount = results.filter((r) => r.alerts && r.alerts.length > 0).length;
+
+  if (dryRun) {
+    console.log(report);
+    console.log(`\n[dry-run] alertCount=${alertCount}`);
+    return;
+  }
+
+  console.log(report);
+
+  // Multi-line GITHUB_OUTPUT — see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+  const ghOutput = process.env.GITHUB_OUTPUT;
+  if (ghOutput) {
+    const eof = `EOF_${Date.now()}`;
+    const payload = `report<<${eof}\n${report}\n${eof}\nalertCount=${alertCount}\nalertCountIsPositive=${alertCount > 0}\n`;
+    fs.appendFileSync(ghOutput, payload);
+  }
+}
+
+main().catch((err) => {
+  console.error(`version-watch: unexpected failure — ${err?.message ?? err}`);
+  // Always exit 0 — failing the workflow because of a transient upstream
+  // outage would be more annoying than missing one weekly report.
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary

Weekly **Monday 08:00 UTC** cron that surveils every package this project supports for **SemVer-major bumps** OR **explicit breaking-change keywords** in upstream release notes. The watcher reports through SMTP email when configured, GitHub issue otherwise.

## Anti-overkill carve-out (explicit)

- ❌ Patches not alerted (Renovate)
- ❌ Non-breaking minors not alerted (Renovate)
- ❌ Prereleases (alpha / beta / rc / next / canary) not alerted (still in flight)
- ✅ SemVer-major bumps : alerted
- ✅ Breaking-change keywords (BREAKING CHANGE / 💥 / etc.) : alerted

## Files added

- \`.github/workflows/version-watch.yml\` — schedule + workflow_dispatch (with dry-run input)
- \`scripts/version-watch.mjs\` — fetch npm + GH releases, render Markdown report (writes to GITHUB_OUTPUT for the workflow)
- \`.github/version-watch-config.json\` — watchlist baseline of 23 packages

## Local dry-run

\`\`\`bash
node scripts/version-watch.mjs --dry-run
\`\`\`

Confirmed: detects \`typescript v5 → v6\` and \`tailwind-variants v0 → v3\` correctly.

## To complete after merge (out-of-scope for this PR)

- Configure repo secrets \`SMTP_HOST\` / \`SMTP_PORT\` / \`SMTP_USER\` / \`SMTP_PASS\` via the GitHub UI to enable the email path. Without these, the watcher will fall back to a GitHub issue (still useful).

## Test plan

- [x] \`node scripts/version-watch.mjs --dry-run\` produces a clean report locally
- [x] GH Actions allowlist updated via API to include \`dawidd6/action-send-mail@*\`
- [x] Action SHA pinning preserved (Scorecard-friendly)
- [ ] After merge, trigger \`gh workflow run version-watch.yml -f dry-run=true\` to confirm the workflow boots cleanly