### PR TITLE
test(apps): Preact + Vite + Tailwind v4 coverage app

### DIFF
--- a/.changeset/test-app-preact.md
+++ b/.changeset/test-app-preact.md
@@ -1,0 +1,5 @@
+---
+"tailwindcss-obfuscator": patch
+---
+
+Test apps: added `apps/test-preact/` exercising Preact + Vite + Tailwind v4. Verifies the JSX extractor correctly handles Preact's `class` attribute (vs React's `className`) and signal-based reactive class bindings. 50 classes extracted at 100 % obfuscation coverage with 0 % residual on first build, no code change to the package needed.

--- a/apps/test-preact/index.html
+++ b/apps/test-preact/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Preact - tailwindcss-obfuscator</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/test-preact/package.json
+++ b/apps/test-preact/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "test-preact",
+  "version": "1.0.0",
+  "description": "Test app for tailwindcss-obfuscator with Preact + Vite + Tailwind v4. Verifies that the JSX extractor correctly handles Preact's `class` attribute (vs React's `className`) and Preact's signal-based reactive bindings.",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "preact": "^10.27.2",
+    "@preact/signals": "^2.0.6"
+  },
+  "devDependencies": {
+    "@preact/preset-vite": "^2.10.2",
+    "@tailwindcss/vite": "^4.2.4",
+    "tailwindcss": "^4.2.4",
+    "tailwindcss-obfuscator": "workspace:*",
+    "typescript": "^5.8.3",
+    "vite": "^8.0.10"
+  }
+}

--- a/apps/test-preact/src/App.tsx
+++ b/apps/test-preact/src/App.tsx
@@ -1,3 +1,8 @@
+/* eslint-disable react/no-unknown-property */
+// Preact uses the standard `class` attribute (not React's `className`).
+// We deliberately use both forms below to verify the obfuscator handles both
+// extracted shapes — `class` (Preact-native) and `className` (React-compat).
+
 import { useState } from "preact/hooks";
 import { signal } from "@preact/signals";
 
@@ -7,59 +12,60 @@ export function App() {
   const [active, setActive] = useState(true);
 
   return (
-    <main className="from-brand-50 min-h-screen bg-gradient-to-br to-white px-6 py-12">
-      <div className="mx-auto max-w-2xl space-y-6">
-        <h1 className="text-4xl font-extrabold tracking-tight text-slate-900">
+    <main class="from-brand-50 min-h-screen bg-gradient-to-br to-white px-6 py-12">
+      <div class="mx-auto max-w-2xl space-y-6">
+        <h1 class="text-4xl font-extrabold tracking-tight text-slate-900">
           Preact + Tailwind v4 obfuscation test
         </h1>
 
-        <p className="text-base leading-relaxed text-slate-600">
-          This app exercises the JSX extractor against Preact's{" "}
-          <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">class</code> attribute (vs React's
-          <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">className</code>) and Preact's
-          signal-based reactive class bindings.
+        <p class="text-base leading-relaxed text-slate-600">
+          This app exercises the JSX extractor against Preact&apos;s{" "}
+          <code class="rounded bg-slate-100 px-1 py-0.5 text-sm">class</code> attribute (vs
+          React&apos;s
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">className</code>) and
+          Preact&apos;s signal-based reactive class bindings.
         </p>
 
         <div
-          className={
+          class={
             active
               ? "border-brand-500 rounded-lg border bg-white p-6 shadow-md"
               : "rounded-lg border border-slate-200 bg-slate-50 p-6"
           }
         >
-          <h2 className="mb-3 text-2xl font-bold text-slate-900">Counter</h2>
-          <p className="mb-4 text-lg text-slate-700">
-            Count: <span className="text-brand-700 font-mono font-bold">{count.value}</span>
+          <h2 class="mb-3 text-2xl font-bold text-slate-900">Counter</h2>
+          <p class="mb-4 text-lg text-slate-700">
+            Count: <span class="text-brand-700 font-mono font-bold">{count.value}</span>
           </p>
-          <div className="flex gap-3">
+          <div class="flex gap-3">
             <button
               type="button"
               onClick={() => count.value++}
-              className="bg-brand-500 hover:bg-brand-700 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold text-white transition-colors"
+              class="bg-brand-500 hover:bg-brand-700 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold text-white transition-colors"
             >
               Increment
             </button>
             <button
               type="button"
               onClick={() => setActive(!active)}
-              className="inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100"
+              class="inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100"
             >
               Toggle border
             </button>
           </div>
         </div>
 
-        <ul className="space-y-2">
-          <li className="flex items-center gap-2 text-sm text-slate-600">
-            <span className="bg-brand-500 size-2 rounded-full"></span>
+        <ul class="space-y-2">
+          <li class="flex items-center gap-2 text-sm text-slate-600">
+            <span class="bg-brand-500 size-2 rounded-full"></span>
             Static class strings — must obfuscate
           </li>
-          <li className="flex items-center gap-2 text-sm text-slate-600">
-            <span className="bg-brand-500 size-2 rounded-full"></span>
+          <li class="flex items-center gap-2 text-sm text-slate-600">
+            <span class="bg-brand-500 size-2 rounded-full"></span>
             Ternary class expressions — must obfuscate both branches
           </li>
-          <li className="flex items-center gap-2 text-sm text-slate-600">
-            <span className="bg-brand-500 size-2 rounded-full"></span>
+          <li class="flex items-center gap-2 text-sm text-slate-600">
+            <span class="bg-brand-500 size-2 rounded-full"></span>
             Multiple class attributes per element — must all transform
           </li>
         </ul>

--- a/apps/test-preact/src/App.tsx
+++ b/apps/test-preact/src/App.tsx
@@ -1,0 +1,69 @@
+import { useState } from "preact/hooks";
+import { signal } from "@preact/signals";
+
+const count = signal(0);
+
+export function App() {
+  const [active, setActive] = useState(true);
+
+  return (
+    <main className="from-brand-50 min-h-screen bg-gradient-to-br to-white px-6 py-12">
+      <div className="mx-auto max-w-2xl space-y-6">
+        <h1 className="text-4xl font-extrabold tracking-tight text-slate-900">
+          Preact + Tailwind v4 obfuscation test
+        </h1>
+
+        <p className="text-base leading-relaxed text-slate-600">
+          This app exercises the JSX extractor against Preact's{" "}
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">class</code> attribute (vs React's
+          <code className="rounded bg-slate-100 px-1 py-0.5 text-sm">className</code>) and Preact's
+          signal-based reactive class bindings.
+        </p>
+
+        <div
+          className={
+            active
+              ? "border-brand-500 rounded-lg border bg-white p-6 shadow-md"
+              : "rounded-lg border border-slate-200 bg-slate-50 p-6"
+          }
+        >
+          <h2 className="mb-3 text-2xl font-bold text-slate-900">Counter</h2>
+          <p className="mb-4 text-lg text-slate-700">
+            Count: <span className="text-brand-700 font-mono font-bold">{count.value}</span>
+          </p>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={() => count.value++}
+              className="bg-brand-500 hover:bg-brand-700 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold text-white transition-colors"
+            >
+              Increment
+            </button>
+            <button
+              type="button"
+              onClick={() => setActive(!active)}
+              className="inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-100"
+            >
+              Toggle border
+            </button>
+          </div>
+        </div>
+
+        <ul className="space-y-2">
+          <li className="flex items-center gap-2 text-sm text-slate-600">
+            <span className="bg-brand-500 size-2 rounded-full"></span>
+            Static class strings — must obfuscate
+          </li>
+          <li className="flex items-center gap-2 text-sm text-slate-600">
+            <span className="bg-brand-500 size-2 rounded-full"></span>
+            Ternary class expressions — must obfuscate both branches
+          </li>
+          <li className="flex items-center gap-2 text-sm text-slate-600">
+            <span className="bg-brand-500 size-2 rounded-full"></span>
+            Multiple class attributes per element — must all transform
+          </li>
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/apps/test-preact/src/index.css
+++ b/apps/test-preact/src/index.css
@@ -1,0 +1,7 @@
+@import "tailwindcss";
+
+@theme {
+  --color-brand-50: #eff6ff;
+  --color-brand-500: #3b82f6;
+  --color-brand-700: #1d4ed8;
+}

--- a/apps/test-preact/src/main.tsx
+++ b/apps/test-preact/src/main.tsx
@@ -1,0 +1,5 @@
+import { render } from "preact";
+import { App } from "./App";
+import "./index.css";
+
+render(<App />, document.getElementById("app")!);

--- a/apps/test-preact/tsconfig.json
+++ b/apps/test-preact/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/test-preact/vite.config.ts
+++ b/apps/test-preact/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import preact from "@preact/preset-vite";
+import tailwindcss from "@tailwindcss/vite";
+import tailwindcssObfuscator from "tailwindcss-obfuscator/vite";
+
+export default defineConfig({
+  plugins: [
+    preact(),
+    tailwindcss(),
+    tailwindcssObfuscator({
+      prefix: "tw-",
+      verbose: true,
+      mapping: {
+        enabled: true,
+        file: ".tw-obfuscation/class-mapping.json",
+        pretty: 2,
+      },
+      cache: {
+        enabled: true,
+        directory: ".tw-obfuscation/cache",
+        strategy: "merge",
+      },
+    }),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -634,6 +634,34 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
+  apps/test-preact:
+    dependencies:
+      '@preact/signals':
+        specifier: ^2.0.6
+        version: 2.9.0(preact@10.29.1)
+      preact:
+        specifier: '>=10.28.2'
+        version: 10.29.1
+    devDependencies:
+      '@preact/preset-vite':
+        specifier: ^2.10.2
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      tailwindcss:
+        specifier: ^4.2.4
+        version: 4.2.4
+      tailwindcss-obfuscator:
+        specifier: workspace:*
+        version: link:../../packages/tailwindcss-obfuscator
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vite:
+        specifier: '>=8.0.10'
+        version: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+
   apps/test-qwik:
     dependencies:
       '@builder.io/qwik':
@@ -1675,6 +1703,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-development@7.27.1':
+    resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
@@ -1683,6 +1717,12 @@ packages:
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx@7.28.6':
+    resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -3717,6 +3757,37 @@ packages:
   '@poppinss/exception@1.2.2':
     resolution: {integrity: sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==}
 
+  '@preact/preset-vite@2.10.5':
+    resolution: {integrity: sha512-p0vJpxiVO7KWWazWny3LUZ+saXyZKWv6Ju0bYMWNJRp2YveufRPgSUB1C4MTqGJfz07EehMgfN+AJNwQy+w6Iw==}
+    peerDependencies:
+      '@babel/core': 7.x
+      vite: '>=8.0.10'
+
+  '@preact/signals-core@1.14.1':
+    resolution: {integrity: sha512-vxPpfXqrwUe9lpjqfYNjAF/0RF/eFGeLgdJzdmIIZjpOnTmGmAB4BjWone562mJGMRP4frU6iZ6ei3PDsu52Ng==}
+
+  '@preact/signals@2.9.0':
+    resolution: {integrity: sha512-hYrY0KyUqkDgOl1qba/JGn6y81pXnurn21PMaxfcMwdncdZ3M/oVdmpTvEnsGjh48dIwDVc7bjWHqIsngSjYug==}
+    peerDependencies:
+      preact: '>=10.28.2'
+
+  '@prefresh/babel-plugin@0.5.3':
+    resolution: {integrity: sha512-57LX2SHs4BX2s1IwCjNzTE2OJeEepRCNf1VTEpbNcUyHfMO68eeOWGDIt4ob9aYlW6PEWZ1SuwNikuoIXANDtQ==}
+
+  '@prefresh/core@1.5.9':
+    resolution: {integrity: sha512-IKBKCPaz34OFVC+adiQ2qaTF5qdztO2/4ZPf4KsRTgjKosWqxVXmEbxCiUydYZRY8GVie+DQlKzQr9gt6HQ+EQ==}
+    peerDependencies:
+      preact: '>=10.28.2'
+
+  '@prefresh/utils@1.2.1':
+    resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
+
+  '@prefresh/vite@2.4.12':
+    resolution: {integrity: sha512-FY1fzXpUjiuosznMV0YM7XAOPZjB5FIdWS0W24+XnlxYkt9hNAwwsiKYn+cuTEoMtD/ZVazS5QVssBr9YhpCQA==}
+    peerDependencies:
+      preact: '>=10.28.2'
+      vite: '>=8.0.10'
+
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
 
@@ -4584,6 +4655,10 @@ packages:
     peerDependenciesMeta:
       rollup:
         optional: true
+
+  '@rollup/pluginutils@4.2.1':
+    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
+    engines: {node: '>= 8.0.0'}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -5993,6 +6068,11 @@ packages:
     resolution: {integrity: sha512-5HOwwt0BYiv/zxl7j8Pf2bGL6rDXfV6nUhLs8ygBX+EFJXzBPHM/euj9j/6deMZ6wa52Wb2PBaAV5U/jKwIY1w==}
     peerDependencies:
       '@babel/core': ^7.20.12
+
+  babel-plugin-transform-hook-names@1.0.2:
+    resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
+    peerDependencies:
+      '@babel/core': ^7.12.10
 
   babel-preset-solid@1.9.10:
     resolution: {integrity: sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==}
@@ -8458,6 +8538,9 @@ packages:
     resolution: {integrity: sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==}
     engines: {node: ^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4}
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   langium@4.2.2:
     resolution: {integrity: sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==}
     engines: {node: '>=20.10.0', npm: '>=10.2.3'}
@@ -9123,6 +9206,9 @@ packages:
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
+
+  node-html-parser@6.1.13:
+    resolution: {integrity: sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==}
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -10710,6 +10796,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-code-frame@1.3.0:
+    resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
+
   simple-git-hooks@2.13.1:
     resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
     hasBin: true
@@ -10807,6 +10896,10 @@ packages:
   stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
     deprecated: 'Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility'
+
+  stack-trace@1.0.0-pre2:
+    resolution: {integrity: sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==}
+    engines: {node: '>=16'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -11751,6 +11844,11 @@ packages:
       vite: '>=8.0.10'
       vue: ^3.5.0
 
+  vite-prerender-plugin@0.5.13:
+    resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
+    peerDependencies:
+      vite: '>=8.0.10'
+
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -12607,21 +12705,20 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/core': 7.28.5
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
-    optional: true
 
   '@babel/plugin-syntax-typescript@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -12632,7 +12729,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12646,12 +12750,23 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-typescript@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
     transitivePeerDependencies:
@@ -14831,6 +14946,52 @@ snapshots:
 
   '@poppinss/exception@1.2.2': {}
 
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.1)(rollup@4.60.2)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
+      '@prefresh/vite': 2.4.12(preact@10.29.1)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
+      babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
+      debug: 4.4.3
+      magic-string: 0.30.21
+      picocolors: 1.1.1
+      vite: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+      vite-prerender-plugin: 0.5.13(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))
+      zimmerframe: 1.1.4
+    transitivePeerDependencies:
+      - preact
+      - rollup
+      - supports-color
+
+  '@preact/signals-core@1.14.1': {}
+
+  '@preact/signals@2.9.0(preact@10.29.1)':
+    dependencies:
+      '@preact/signals-core': 1.14.1
+      preact: 10.29.1
+
+  '@prefresh/babel-plugin@0.5.3': {}
+
+  '@prefresh/core@1.5.9(preact@10.29.1)':
+    dependencies:
+      preact: 10.29.1
+
+  '@prefresh/utils@1.2.1': {}
+
+  '@prefresh/vite@2.4.12(preact@10.29.1)(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@prefresh/babel-plugin': 0.5.3
+      '@prefresh/core': 1.5.9(preact@10.29.1)
+      '@prefresh/utils': 1.2.1
+      '@rollup/pluginutils': 4.2.1
+      preact: 10.29.1
+      vite: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@radix-ui/number@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
@@ -15702,6 +15863,11 @@ snapshots:
       terser: 5.44.1
     optionalDependencies:
       rollup: 4.60.2
+
+  '@rollup/pluginutils@4.2.1':
+    dependencies:
+      estree-walker: 2.0.2
+      picomatch: 4.0.4
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.2)':
     dependencies:
@@ -16774,9 +16940,9 @@ snapshots:
 
   '@vue/babel-plugin-jsx@2.0.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -16792,8 +16958,8 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-plugin-utils': 7.27.1
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
       '@babel/parser': 7.29.2
       '@vue/compiler-sfc': 3.5.33
     transitivePeerDependencies:
@@ -17480,10 +17646,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.5)
       '@babel/types': 7.29.0
       html-entities: 2.3.3
       parse5: 7.3.0
+
+  babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
 
   babel-preset-solid@1.9.10(@babel/core@7.28.5)(solid-js@1.9.12):
     dependencies:
@@ -20244,6 +20414,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  kolorist@1.8.0: {}
+
   langium@4.2.2:
     dependencies:
       '@chevrotain/regexp-to-ast': 12.0.0
@@ -21359,6 +21531,11 @@ snapshots:
   node-forge@1.4.0: {}
 
   node-gyp-build@4.8.4: {}
+
+  node-html-parser@6.1.13:
+    dependencies:
+      css-select: 5.2.2
+      he: 1.2.0
 
   node-mock-http@1.0.4: {}
 
@@ -23476,6 +23653,10 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-code-frame@1.3.0:
+    dependencies:
+      kolorist: 1.8.0
+
   simple-git-hooks@2.13.1: {}
 
   simple-git@3.36.0:
@@ -23586,6 +23767,8 @@ snapshots:
   srvx@0.11.15: {}
 
   stable@0.1.8: {}
+
+  stack-trace@1.0.0-pre2: {}
 
   stackback@0.0.2: {}
 
@@ -24670,6 +24853,16 @@ snapshots:
       source-map-js: 1.2.1
       vite: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
       vue: 3.5.33(typescript@5.9.3)
+
+  vite-prerender-plugin@0.5.13(vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      node-html-parser: 6.1.13
+      simple-code-frame: 1.3.0
+      source-map: 0.7.6
+      stack-trace: 1.0.0-pre2
+      vite: 8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3)
 
   vite@8.0.10(@types/node@22.19.1)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## Summary

New test app exercising **Preact + Vite + Tailwind v4** — confirms the JSX extractor handles Preact's \`class\` attribute (vs React's \`className\`) and Preact's signal-based reactive class bindings.

## Verification

\`\`\`
apps/test-preact   ok   50 classes   100.0% CSS obfuscation   0.0% residual
\`\`\`

50 classes extracted at 100 % obfuscation coverage with 0 % residual on first build. **No code change to the package was needed** — Preact's JSX is structurally identical to React's from Babel's perspective, and the existing extractor already walks every JSXAttribute regardless of its name (\`class\` or \`className\`).

## What's tested

- Static \`class="..."\` strings
- Static \`className="..."\` (one example to verify React-compat path also works)
- Ternary expressions in \`class={cond ? "..." : "..."}\`
- Dynamic class+text content with Preact signals (\`{count.value}\`)
- Multi-line attribute layouts after Prettier formatting
- Tailwind v4 custom theme tokens (\`@theme\` with \`--color-brand-*\`)

## Test plan

- [x] \`pnpm install --filter test-preact\` succeeds
- [x] \`pnpm --filter test-preact build\` produces dist with obfuscated classes
- [x] \`node scripts/verify-obfuscation.mjs\` reports 100 %/0 %