### PR TITLE
docs: 301-style redirect /guides/<slug> → /guide/<slug>

### DIFF
--- a/docs/public/guides/astro.html
+++ b/docs/public/guides/astro.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/astro</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/astro" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/astro" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/astro" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/astro">/guide/astro</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/brand-assets.html
+++ b/docs/public/guides/brand-assets.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/brand-assets</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/brand-assets" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/brand-assets" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/brand-assets" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/brand-assets">/guide/brand-assets</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/class-utilities.html
+++ b/docs/public/guides/class-utilities.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/class-utilities</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/class-utilities" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/class-utilities" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/class-utilities" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/class-utilities">/guide/class-utilities</a> (singular),
+      not <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/esbuild.html
+++ b/docs/public/guides/esbuild.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/esbuild</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/esbuild" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/esbuild" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/esbuild" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/esbuild">/guide/esbuild</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/exclusions.html
+++ b/docs/public/guides/exclusions.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/exclusions</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/exclusions" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/exclusions" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/exclusions" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/exclusions">/guide/exclusions</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/farm.html
+++ b/docs/public/guides/farm.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/farm</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/farm" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/farm" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/farm" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/farm">/guide/farm</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/getting-started.html
+++ b/docs/public/guides/getting-started.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/getting-started</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/getting-started" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/getting-started" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/getting-started" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/getting-started">/guide/getting-started</a> (singular),
+      not <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/index.html
+++ b/docs/public/guides/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/getting-started" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/getting-started" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/getting-started");
+    </script>
+  </head>
+  <body>
+    <p>
+      The documentation lives under
+      <a href="/tailwindcss-obfuscator/guide/getting-started">/guide/</a> (singular). Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/nextjs.html
+++ b/docs/public/guides/nextjs.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/nextjs</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/nextjs" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/nextjs" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/nextjs" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/nextjs">/guide/nextjs</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/nuxt.html
+++ b/docs/public/guides/nuxt.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/nuxt</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/nuxt" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/nuxt" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/nuxt" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/nuxt">/guide/nuxt</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/options.html
+++ b/docs/public/guides/options.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/options</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/options" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/options" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/options" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/options">/guide/options</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/qwik.html
+++ b/docs/public/guides/qwik.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/qwik</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/qwik" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/qwik" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/qwik" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/qwik">/guide/qwik</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/react-router.html
+++ b/docs/public/guides/react-router.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/react-router</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/react-router" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/react-router" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/react-router" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/react-router">/guide/react-router</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/rollup-standalone.html
+++ b/docs/public/guides/rollup-standalone.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/rollup-standalone</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/rollup-standalone" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/rollup-standalone" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/rollup-standalone" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/rollup-standalone">/guide/rollup-standalone</a>
+      (singular), not <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/rspack.html
+++ b/docs/public/guides/rspack.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/rspack</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/rspack" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/rspack" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/rspack" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/rspack">/guide/rspack</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/solid.html
+++ b/docs/public/guides/solid.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/solid</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/solid" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/solid" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/solid" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/solid">/guide/solid</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/sveltekit.html
+++ b/docs/public/guides/sveltekit.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/sveltekit</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/sveltekit" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/sveltekit" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/sveltekit" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/sveltekit">/guide/sveltekit</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/tanstack-router.html
+++ b/docs/public/guides/tanstack-router.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/tanstack-router</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/tanstack-router" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/tanstack-router" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/tanstack-router" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/tanstack-router">/guide/tanstack-router</a> (singular),
+      not <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/vite.html
+++ b/docs/public/guides/vite.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/vite</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/vite" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/vite" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/vite" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/vite">/guide/vite</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/vue.html
+++ b/docs/public/guides/vue.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/vue</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/vue" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/vue" />
+    <script>
+      location.replace("/tailwindcss-obfuscator/guide/vue" + location.search + location.hash);
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/vue">/guide/vue</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/webpack-standalone.html
+++ b/docs/public/guides/webpack-standalone.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/webpack-standalone</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/webpack-standalone" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/webpack-standalone" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/webpack-standalone" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/webpack-standalone">/guide/webpack-standalone</a>
+      (singular), not <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/what-is-it.html
+++ b/docs/public/guides/what-is-it.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/what-is-it</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/what-is-it" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/what-is-it" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/what-is-it" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/what-is-it">/guide/what-is-it</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>

--- a/docs/public/guides/why-obfuscate.html
+++ b/docs/public/guides/why-obfuscate.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Redirecting to /guide/why-obfuscate</title>
+    <meta http-equiv="refresh" content="0; url=/tailwindcss-obfuscator/guide/why-obfuscate" />
+    <link rel="canonical" href="/tailwindcss-obfuscator/guide/why-obfuscate" />
+    <script>
+      location.replace(
+        "/tailwindcss-obfuscator/guide/why-obfuscate" + location.search + location.hash
+      );
+    </script>
+  </head>
+  <body>
+    <p>
+      The guide pages live under
+      <a href="/tailwindcss-obfuscator/guide/why-obfuscate">/guide/why-obfuscate</a> (singular), not
+      <code>/guides/</code>. Redirecting…
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

External references occasionally land on `/guides/<slug>` (plural) which 404s because every guide page actually lives under `/guide/<slug>` (singular, per VitePress sidebar config). Adds a static HTML redirect for every existing guide slug under `docs/public/guides/`, plus an `/guides/` index → `/guide/getting-started`.

The redirects use both `<meta http-equiv=refresh>` AND a `<script>location.replace()` for instant browser navigation, preserving the search/hash.

## Verification

```
curl -s -o /dev/null -w '%{http_code}' .../guide/nextjs   → 200
curl -s -o /dev/null -w '%{http_code}' .../guides/nextjs  → 404 (today, 200 after merge)
```