### PR TITLE
fix(docs): hero buttons actually full-width (follow-up to #128)

### DIFF
--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -699,12 +699,21 @@ h3 {
    on the right). We pull .actions out of the flex flow with absolute
    positioning so the three CTAs sit on a single horizontal row that spans
    the full container width, centered, below the logo + text block.
+
+   Critical : VitePress's default theme sets .VPHero .main { position: relative },
+   which would trap the absolute .actions inside the 45 %-wide left column.
+   We force .main back to position: static so the absolute child resolves
+   to .container (the only relative ancestor).
    ============================================================================= */
 
 @media (min-width: 960px) {
   .VPHero .container {
     position: relative !important;
     padding-bottom: 7rem !important;
+  }
+
+  .VPHero .main {
+    position: static !important;
   }
 
   .VPHero .main .actions {


### PR DESCRIPTION
## Summary

PR #128 was supposed to make the hero CTAs sit on a single horizontal row spanning the container, below the logo+text block. The CSS used `position: absolute; left: 0; right: 0` on `.VPHero .main .actions`, expecting the absolute positioning to anchor to `.VPHero .container` (which we made `position: relative`).

It didn't work because VitePress's default theme sets `.VPHero .main { position: relative }`. The absolute element therefore resolved its containing block to `.main` (the 45 %-wide left column), not `.container` (full-width). User screenshot confirmed the actions sat at 584 px wide instead of the full container.

Fix: force `.VPHero .main { position: static !important }` so the next `position: relative` ancestor of `.actions` is `.container`.

## Test plan

- [x] `pnpm docs:build` green
- [ ] After GitHub Pages deploy, verify the three buttons render as a centered horizontal row at full container width below the logo + text block on https://josedacosta.github.io/tailwindcss-obfuscator/